### PR TITLE
Volume/Vserver updates

### DIFF
--- a/netapp/base.go
+++ b/netapp/base.go
@@ -16,10 +16,21 @@ type Base struct {
 type ResultBase struct {
 	Status     string `xml:"status,attr"`
 	Reason     string `xml:"reason,attr"`
-	NumRecords string `json:"num-records"`
+	NumRecords int    `json:"num-records"`
+	ErrorNo    int    `xml:"errno,attr"`
+}
+
+type SingleResultBase struct {
+	Status  string `xml:"status,attr"`
+	Reason  string `xml:"reason,attr"`
+	ErrorNo int    `xml:"errno,attr"`
 }
 
 func (r *ResultBase) Passed() bool {
+	return r.Status == "passed"
+}
+
+func (r *SingleResultBase) Passed() bool {
 	return r.Status == "passed"
 }
 

--- a/netapp/netapp.go
+++ b/netapp/netapp.go
@@ -22,30 +22,31 @@ const (
 
 // A Client manages communication with the GitHub API.
 type Client struct {
-	client          *http.Client
-	BaseURL         *url.URL
-	UserAgent       string
-	options         *ClientOptions
-	Aggregate       *Aggregate
-	AggregateSpace  *AggregateSpace
-	AggregateSpares *AggregateSpares
-	Cf              *Cf
-	Diagnosis       *Diagnosis
-	Fcp             *Fcp
-	Fcport          *Fcport
-	Job             *Job
-	Lun             *Lun
-	Net             *Net
-	Qtree           *Qtree
-	Quota           *Quota
-	QuotaReport     *QuotaReport
-	QuotaStatus     *QuotaStatus
-	Snapshot        *Snapshot
-	StorageDisk     *StorageDisk
-	System          *System
-	Volume          *Volume
-	VolumeSpace     *VolumeSpace
-	VServer         *VServer
+	client           *http.Client
+	BaseURL          *url.URL
+	UserAgent        string
+	options          *ClientOptions
+	Aggregate        *Aggregate
+	AggregateSpace   *AggregateSpace
+	AggregateSpares  *AggregateSpares
+	Cf               *Cf
+	Diagnosis        *Diagnosis
+	Fcp              *Fcp
+	Fcport           *Fcport
+	Job              *Job
+	Lun              *Lun
+	Net              *Net
+	Qtree            *Qtree
+	Quota            *Quota
+	QuotaReport      *QuotaReport
+	QuotaStatus      *QuotaStatus
+	Snapshot         *Snapshot
+	StorageDisk      *StorageDisk
+	System           *System
+	Volume           *Volume
+	VolumeSpace      *VolumeSpace
+	VolumeOperations *VolumeOperation
+	VServer          *VServer
 }
 
 type ClientOptions struct {
@@ -166,6 +167,10 @@ func NewClient(endpoint string, version string, options *ClientOptions) *Client 
 	}
 
 	c.VolumeSpace = &VolumeSpace{
+		Base: b,
+	}
+
+	c.VolumeOperations = &VolumeOperation{
 		Base: b,
 	}
 

--- a/netapp/volume-modify.go
+++ b/netapp/volume-modify.go
@@ -1,0 +1,40 @@
+package netapp
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+type VolumeModifyOptions struct {
+	*VolumeOptions
+	ContinueOnFailure bool `xml:"continue-on-failure,omitempty"`
+	MaxFailureCount   int  `xml:"max-failure-count,omitempty"`
+	ReturnFailureList bool `xml:"return-failure-list,omitempty"`
+	ReturnSuccessList bool `xml:"return-success-list,omitempty"`
+}
+
+type VolumeModifyResponce struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+		FailureList     *[]VolumeModifyInfo `xml:"failure-list>volume-modify-iter-info"`
+		SuccessList     *[]VolumeModifyInfo `xml:"success-list>volume-modify-iter-info"`
+		NextTag         string              `xml:"next-tag"`
+		NumberSucceeded int                 `xml:"num-succeeded"`
+		NumberFailed    int                 `xml:"num-failed"`
+	} `xml:"results"`
+}
+
+type VolumeModifyInfo struct {
+	ErrorCode    int         `xml:"error-code,omitempty"`
+	ErrorMessage string      `xml:"error-message,omitempty"`
+	VolumeKey    *VolumeInfo `xml:"volume-key,omitempty"`
+}
+
+func (v *Volume) Modify(options *VolumeOptions) (*VolumeModifyResponce, *http.Response, error) {
+	v.Params.XMLName = xml.Name{Local: "volume-modify-iter"}
+	v.Params.VolumeOptions = options
+	r := VolumeModifyResponce{}
+	res, err := v.get(v, &r)
+	return &r, res, err
+}

--- a/netapp/volume-operations.go
+++ b/netapp/volume-operations.go
@@ -1,0 +1,104 @@
+package netapp
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+const (
+	VolumeCreateOperation   = "volume-create"
+	VolumeOfflineOperation  = "volume-offline"
+	VolumeOnlineOperation   = "volume-online"
+	VolumeDestroyOperation  = "volume-destroy"
+	VolumeUnmountOperation  = "volume-unmount"
+	VolumeRestrictOperation = "volume-restrict"
+)
+
+type VolumeOperation struct {
+	Base
+	Params struct {
+		XMLName    xml.Name
+		VolumeName *volumeName
+		*VolumeCreateOptions
+	}
+}
+
+type volumeName struct {
+	XMLName xml.Name
+	Name    string `xml:",innerxml"`
+}
+
+type VolumeCreateOptions struct {
+	AntivirusOnAccessPolicy    string `xml:"antivirus-on-access-policy,omitempty"`
+	CacheRetentionPriority     string `xml:"cache-retention-priority,omitempty"`
+	CachingPolicy              string `xml:"caching-policy,omitempty"`
+	ConstituentRole            string `xml:"constituent-role,omitempty"`
+	ContainingAggregateName    string `xml:"containing-aggr-name,omitempty"`
+	EfficiencyPolicy           string `xml:"efficiency-policy,omitempty"`
+	Encrypt                    bool   `xml:"encrypt,omitempty"`
+	ExcludedFromAutobalance    bool   `xml:"excluded-from-autobalance,omitempty"`
+	ExportPolicy               string `xml:"export-policy,omitempty"`
+	ExtentSize                 string `xml:"extent-size,omitempty"`
+	FlexcachePolicy            string `xml:"flexcache-cache-policy,omitempty"`
+	FlexcacheFillPolicy        string `xml:"flexcache-fill-policy,omitempty"`
+	FlexcacheOriginVolumeName  string `xml:"flexcache-origin-volume-name,omitempty"`
+	GroupID                    int    `xml:"group-id,omitempty"`
+	IsJunctionActive           bool   `xml:"is-junction-active,omitempty"`
+	IsNvfailEnabled            string `xml:"is-nvfail-enabled,omitempty"`
+	IsVserverRoot              bool   `xml:"is-vserver-root,omitempty"`
+	JunctionPath               string `xml:"junction-path,omitempty"`
+	LanguageCode               string `xml:"language-code,omitempty"`
+	MaxDirSize                 int    `xml:"max-dir-size,omitempty"`
+	MaxWriteAllocBlocks        int    `xml:"max-write-alloc-blocks,omitempty"`
+	PercentageSnapshotReserve  int    `xml:"percentage-snapshot-reserve,omitempty"`
+	QosAdaptivePolicyGroupName string `xml:"qos-adaptive-policy-group-name,omitempty"`
+	QosPolicyGroupName         string `xml:"qos-policy-group-name,omitempty"`
+	Size                       string `xml:"size,omitempty"`
+	SnapshotPolicy             string `xml:"snapshot-policy,omitempty"`
+	SpaceReserve               string `xml:"space-reserve,omitempty"`
+	SpaceSlo                   string `xml:"space-slo,omitempty"`
+	StorageService             string `xml:"storage-service,omitempty"`
+	TieringPolicy              string `xml:"tiering-policy,omitempty"`
+	UnixPermissions            string `xml:"unix-permissions,omitempty"`
+	UserID                     int    `xml:"user-id,omitempty"`
+	VMAlignSector              int    `xml:"vm-align-sector,omitempty"`
+	VMAlignSuffix              string `xml:"vm-align-suffix,omitempty"`
+	Volume                     string `xml:"volume,omitempty"`
+	VolumeComment              string `xml:"volume-comment,omitempty"`
+	VolumeSecurityStyle        string `xml:"volume-security-style,omitempty"`
+	VolumeState                string `xml:"volume-state,omitempty"`
+	VolumeType                 string `xml:"volume-type,omitempty"`
+	VserverDrProtection        string `xml:"vserver-dr-protection,omitempty"`
+}
+
+type VolumeOperationResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+	} `xml:"results"`
+}
+
+func (v *VolumeOperation) Create(options *VolumeCreateOptions, vserverName string) (*VolumeOperationResponse, *http.Response, error) {
+	v.Params.XMLName = xml.Name{Local: VolumeCreateOperation}
+	v.Name = vserverName
+	v.Params.VolumeCreateOptions = options
+	r := VolumeOperationResponse{}
+	res, err := v.get(v, &r)
+	return &r, res, err
+}
+
+func (v *VolumeOperation) Operation(volName string, vserverName string, operation string) (*VolumeOperationResponse, *http.Response, error) {
+	v.Params.XMLName = xml.Name{Local: operation}
+	v.Name = vserverName
+	elementName := "name"
+	if operation == VolumeUnmountOperation {
+		elementName = "volume-name"
+	}
+	v.Params.VolumeName = &volumeName{
+		XMLName: xml.Name{Local: elementName},
+		Name:    volName,
+	}
+	r := VolumeOperationResponse{}
+	res, err := v.get(v, &r)
+	return &r, res, err
+}

--- a/netapp/volume.go
+++ b/netapp/volume.go
@@ -14,10 +14,11 @@ type Volume struct {
 }
 
 type VolumeQuery struct {
-	VolumeInfo *VolumeInfo `xml:"volume-info,omitempty"`
+	VolumeInfo *VolumeInfo `xml:"volume-attributes,omitempty"`
 }
 type VolumeOptions struct {
 	DesiredAttributes *VolumeQuery `xml:"desired-attributes,omitempty"`
+	Attributes        *VolumeQuery `xml:"attributes,omitempty"`
 	MaxRecords        int          `xml:"max-records,omitempty"`
 	Query             *VolumeQuery `xml:"query,omitempty"`
 	Tag               string       `xml:"tag,omitempty"`
@@ -50,32 +51,28 @@ type VolumeHybridCacheAttributes struct {
 	Eligibility            string `xml:"eligibility"`
 }
 type VolumeIDAttributes struct {
-	AggrList struct {
-		AggrName string `xml:"aggr-name"`
-	} `xml:"aggr-list"`
-	Comment                 string `xml:"comment"`
-	ContainingAggregateName string `xml:"containing-aggregate-name"`
-	ContainingAggregateUUID string `xml:"containing-aggregate-uuid"`
-	CreationTime            string `xml:"creation-time"`
-	Dsid                    string `xml:"dsid"`
-	Fsid                    string `xml:"fsid"`
-	InstanceUUID            string `xml:"instance-uuid"`
-	JunctionParentName      string `xml:"junction-parent-name"`
-	JunctionPath            string `xml:"junction-path"`
-	Msid                    string `xml:"msid"`
-	Name                    string `xml:"name"`
-	NameOrdinal             string `xml:"name-ordinal"`
-	Node                    string `xml:"node"`
-	Nodes                   struct {
-		NodeName string `xml:"node-name"`
-	} `xml:"nodes"`
-	OwningVserverName string `xml:"owning-vserver-name"`
-	OwningVserverUUID string `xml:"owning-vserver-uuid"`
-	ProvenanceUUID    string `xml:"provenance-uuid"`
-	Style             string `xml:"style"`
-	StyleExtended     string `xml:"style-extended"`
-	Type              string `xml:"type"`
-	UUID              string `xml:"uuid"`
+	AggrList                []string `xml:"aggr-list>aggr-name,omitempty"`
+	Comment                 string   `xml:"comment,omitempty"`
+	ContainingAggregateName string   `xml:"containing-aggregate-name,omitempty"`
+	ContainingAggregateUUID string   `xml:"containing-aggregate-uuid,omitempty"`
+	CreationTime            string   `xml:"creation-time,omitempty"`
+	Dsid                    string   `xml:"dsid,omitempty"`
+	Fsid                    string   `xml:"fsid,omitempty"`
+	InstanceUUID            string   `xml:"instance-uuid,omitempty"`
+	JunctionParentName      string   `xml:"junction-parent-name,omitempty"`
+	JunctionPath            string   `xml:"junction-path,omitempty"`
+	Msid                    string   `xml:"msid,omitempty"`
+	Name                    string   `xml:"name,omitempty"`
+	NameOrdinal             string   `xml:"name-ordinal,omitempty"`
+	Node                    string   `xml:"node,omitempty"`
+	Nodes                   []string `xml:"nodes>node-name,omitempty"`
+	OwningVserverName       string   `xml:"owning-vserver-name,omitempty"`
+	OwningVserverUUID       string   `xml:"owning-vserver-uuid,omitempty"`
+	ProvenanceUUID          string   `xml:"provenance-uuid,omitempty"`
+	Style                   string   `xml:"style,omitempty"`
+	StyleExtended           string   `xml:"style-extended,omitempty"`
+	Type                    string   `xml:"type,omitempty"`
+	UUID                    string   `xml:"uuid,omitempty"`
 }
 type VolumeInodeAttributes struct {
 	BlockType                string `xml:"block-type"`
@@ -110,6 +107,13 @@ type VolumePerformanceAttributes struct {
 	MinimalReadAhead     string `xml:"minimal-read-ahead"`
 	ReadRealloc          string `xml:"read-realloc"`
 }
+
+// VolumeQosAttributes is for tracking QOS-related volume attributes
+type VolumeQosAttributes struct {
+	AdaptivePolicyGroupName string `xml:"adaptive-policy-group-name,omitempty"`
+	PolicyGroupName         string `xml:"policy-group-name"`
+}
+
 type VolumeSecurityAttributes struct {
 	Style                        string `xml:"style"`
 	VolumeSecurityUnixAttributes struct {
@@ -134,11 +138,11 @@ type VolumeSnaplockAttributes struct {
 	SnaplockType string `xml:"snaplock-type"`
 }
 type VolumeSnapshotAttributes struct {
-	AutoSnapshotsEnabled           string `xml:"auto-snapshots-enabled"`
-	SnapdirAccessEnabled           string `xml:"snapdir-access-enabled"`
-	SnapshotCloneDependencyEnabled string `xml:"snapshot-clone-dependency-enabled"`
-	SnapshotCount                  string `xml:"snapshot-count"`
-	SnapshotPolicy                 string `xml:"snapshot-policy"`
+	AutoSnapshotsEnabled           string `xml:"auto-snapshots-enabled,omitempty"`
+	SnapdirAccessEnabled           bool   `xml:"snapdir-access-enabled,omitempty"`
+	SnapshotCloneDependencyEnabled string `xml:"snapshot-clone-dependency-enabled,omitempty"`
+	SnapshotCount                  string `xml:"snapshot-count,omitempty"`
+	SnapshotPolicy                 string `xml:"snapshot-policy,omitempty"`
 }
 type VolumeSnapshotAutodeleteAttributes struct {
 	Commitment          string `xml:"commitment"`
@@ -165,7 +169,7 @@ type VolumeSpaceAttributes struct {
 	PercentageSnapshotReserveUsed   string `xml:"percentage-snapshot-reserve-used"`
 	PhysicalUsed                    string `xml:"physical-used"`
 	PhysicalUsedPercent             string `xml:"physical-used-percent"`
-	Size                            string `xml:"size"`
+	Size                            int    `xml:"size"`
 	SizeAvailable                   string `xml:"size-available"`
 	SizeAvailableForSnapshots       string `xml:"size-available-for-snapshots"`
 	SizeTotal                       string `xml:"size-total"`
@@ -207,38 +211,37 @@ type VolumeTransitionAttributes struct {
 }
 
 type VolumeInfo struct {
-	Encrypt                            string                             `xml:"encrypt"`
-	KeyID                              string                             `xml:"key-id,omitempty"`
-	VolumeAntivirusAttributes          VolumeAntivirusAttributes          `xml:"volume-antivirus-attributes,omitempty"`
-	VolumeAutobalanceAttributes        VolumeAutobalanceAttributes        `xml:"volume-autobalance-attributes,omitempty"`
-	VolumeAutosizeAttributes           VolumeAutosizeAttributes           `xml:"volume-autosize-attributes"`
-	VolumeDirectoryAttributes          VolumeDirectoryAttributes          `xml:"volume-directory-attributes"`
-	VolumeExportAttributes             VolumeExportAttributes             `xml:"volume-export-attributes,omitempty"`
-	VolumeHybridCacheAttributes        VolumeHybridCacheAttributes        `xml:"volume-hybrid-cache-attributes"`
-	VolumeIDAttributes                 VolumeIDAttributes                 `xml:"volume-id-attributes"`
-	VolumeInodeAttributes              VolumeInodeAttributes              `xml:"volume-inode-attributes"`
-	VolumeLanguageAttributes           VolumeLanguageAttributes           `xml:"volume-language-attributes"`
-	VolumeMirrorAttributes             VolumeMirrorAttributes             `xml:"volume-mirror-attributes"`
-	VolumePerformanceAttributes        VolumePerformanceAttributes        `xml:"volume-performance-attributes"`
-	VolumeSecurityAttributes           VolumeSecurityAttributes           `xml:"volume-security-attributes"`
-	VolumeSisAttributes                VolumeSisAttributes                `xml:"volume-sis-attributes"`
-	VolumeSnaplockAttributes           VolumeSnaplockAttributes           `xml:"volume-snaplock-attributes,omitempty"`
-	VolumeSnapshotAttributes           VolumeSnapshotAttributes           `xml:"volume-snapshot-attributes"`
-	VolumeSnapshotAutodeleteAttributes VolumeSnapshotAutodeleteAttributes `xml:"volume-snapshot-autodelete-attributes"`
-	VolumeSpaceAttributes              VolumeSpaceAttributes              `xml:"volume-space-attributes"`
-	VolumeStateAttributes              VolumeStateAttributes              `xml:"volume-state-attributes"`
-	VolumeTransitionAttributes         VolumeTransitionAttributes         `xml:"volume-transition-attributes"`
+	Encrypt                            string                              `xml:"encrypt,omitempty"`
+	KeyID                              string                              `xml:"key-id,omitempty"`
+	VolumeAntivirusAttributes          *VolumeAntivirusAttributes          `xml:"volume-antivirus-attributes,omitempty"`
+	VolumeAutobalanceAttributes        *VolumeAutobalanceAttributes        `xml:"volume-autobalance-attributes,omitempty"`
+	VolumeAutosizeAttributes           *VolumeAutosizeAttributes           `xml:"volume-autosize-attributes"`
+	VolumeDirectoryAttributes          *VolumeDirectoryAttributes          `xml:"volume-directory-attributes"`
+	VolumeExportAttributes             *VolumeExportAttributes             `xml:"volume-export-attributes,omitempty"`
+	VolumeHybridCacheAttributes        *VolumeHybridCacheAttributes        `xml:"volume-hybrid-cache-attributes,omitempty"`
+	VolumeIDAttributes                 *VolumeIDAttributes                 `xml:"volume-id-attributes,omitempty"`
+	VolumeInodeAttributes              *VolumeInodeAttributes              `xml:"volume-inode-attributes,omitempty"`
+	VolumeLanguageAttributes           *VolumeLanguageAttributes           `xml:"volume-language-attributes,omitempty"`
+	VolumeMirrorAttributes             *VolumeMirrorAttributes             `xml:"volume-mirror-attributes,omitempty"`
+	VolumePerformanceAttributes        *VolumePerformanceAttributes        `xml:"volume-performance-attributes,omitempty"`
+	VolumeQosAttributes                *VolumeQosAttributes                `xml:"volume-qos-attributes,omitempty"`
+	VolumeSecurityAttributes           *VolumeSecurityAttributes           `xml:"volume-security-attributes,omitempty"`
+	VolumeSisAttributes                *VolumeSisAttributes                `xml:"volume-sis-attributes,omitempty"`
+	VolumeSnaplockAttributes           *VolumeSnaplockAttributes           `xml:"volume-snaplock-attributes,omitempty"`
+	VolumeSnapshotAttributes           *VolumeSnapshotAttributes           `xml:"volume-snapshot-attributes,omitempty"`
+	VolumeSnapshotAutodeleteAttributes *VolumeSnapshotAutodeleteAttributes `xml:"volume-snapshot-autodelete-attributes,omitempty"`
+	VolumeSpaceAttributes              *VolumeSpaceAttributes              `xml:"volume-space-attributes,omitempty"`
+	VolumeStateAttributes              *VolumeStateAttributes              `xml:"volume-state-attributes,omitempty"`
+	VolumeTransitionAttributes         *VolumeTransitionAttributes         `xml:"volume-transition-attributes,omitempty"`
 }
 
 type VolumeListResponse struct {
 	XMLName xml.Name `xml:"netapp"`
 	Results struct {
 		ResultBase
-		AttributesList struct {
-			VolumeAttributes []VolumeInfo `xml:"volume-attributes"`
-		} `xml:"attributes-list"`
-		NextTag    string `xml:"next-tag"`
-		NumRecords int    `xml:"num-records"`
+		AttributesList []VolumeInfo `xml:"attributes-list>volume-attributes"`
+		NextTag        string       `xml:"next-tag"`
+		NumRecords     int          `xml:"num-records"`
 	} `xml:"results"`
 }
 

--- a/netapp/vserver.go
+++ b/netapp/vserver.go
@@ -14,37 +14,30 @@ type VServer struct {
 }
 
 type VServerInfo struct {
-	AntivirusOnAccessPolicy string `xml:"antivirus-on-access-policy"`
-	Comment                 string `xml:"comment"`
-	Ipspace                 string `xml:"ipspace,omitempty"`
-	IsRepositoryVserver     string `xml:"is-repository-vserver"`
-	SnapshotPolicy          string `xml:"snapshot-policy,omitempty"`
-	UUID                    string `xml:"uuid"`
-	VserverName             string `xml:"vserver-name"`
-	VserverType             string `xml:"vserver-type"`
-	AllowedProtocols        struct {
-		Protocol []string `xml:"protocol"`
-	} `xml:"allowed-protocols,omitempty"`
-	DisallowedProtocols struct {
-		Protocol []string `xml:"protocol"`
-	} `xml:"disallowed-protocols,omitempty"`
-	IsConfigLockedForChanges string `xml:"is-config-locked-for-changes,omitempty"`
-	Language                 string `xml:"language,omitempty"`
-	MaxVolumes               string `xml:"max-volumes,omitempty"`
-	NameMappingSwitch        struct {
-		Nmswitch string `xml:"nmswitch"`
-	} `xml:"name-mapping-switch,omitempty"`
-	NameServerSwitch struct {
-		Nsswitch string `xml:"nsswitch"`
-	} `xml:"name-server-switch,omitempty"`
-	OperationalState           string `xml:"operational-state,omitempty"`
-	QuotaPolicy                string `xml:"quota-policy,omitempty"`
-	RootVolume                 string `xml:"root-volume,omitempty"`
-	RootVolumeAggregate        string `xml:"root-volume-aggregate,omitempty"`
-	RootVolumeSecurityStyle    string `xml:"root-volume-security-style,omitempty"`
-	State                      string `xml:"state,omitempty"`
-	VolumeDeleteRetentionHours string `xml:"volume-delete-retention-hours,omitempty"`
-	VserverSubtype             string `xml:"vserver-subtype,omitempty"`
+	AntivirusOnAccessPolicy    string   `xml:"antivirus-on-access-policy,omitempty"`
+	AggregateList              []string `xml:"aggr-list>aggr-name"`
+	Comment                    string   `xml:"comment,omitempty"`
+	Ipspace                    string   `xml:"ipspace,omitempty"`
+	IsRepositoryVserver        string   `xml:"is-repository-vserver,omitempty"`
+	SnapshotPolicy             string   `xml:"snapshot-policy,omitempty"`
+	UUID                       string   `xml:"uuid,omitempty"`
+	VserverName                string   `xml:"vserver-name,omitempty"`
+	VserverType                string   `xml:"vserver-type,omitempty"`
+	AllowedProtocols           []string `xml:"allowed-protocols>protocol,omitempty"`
+	DisallowedProtocols        []string `xml:"disallowed-protocols>protocol,omitempty"`
+	IsConfigLockedForChanges   string   `xml:"is-config-locked-for-changes,omitempty"`
+	Language                   string   `xml:"language,omitempty"`
+	MaxVolumes                 string   `xml:"max-volumes,omitempty"`
+	NameMappingSwitch          []string `xml:"name-mapping-switch>nmswitch,omitempty"`
+	NameServerSwitch           []string `xml:"name-server-switch>nsswitch,omitempty"`
+	OperationalState           string   `xml:"operational-state,omitempty"`
+	QuotaPolicy                string   `xml:"quota-policy,omitempty"`
+	RootVolume                 string   `xml:"root-volume,omitempty"`
+	RootVolumeAggregate        string   `xml:"root-volume-aggregate,omitempty"`
+	RootVolumeSecurityStyle    string   `xml:"root-volume-security-style,omitempty"`
+	State                      string   `xml:"state,omitempty"`
+	VolumeDeleteRetentionHours int      `xml:"volume-delete-retention-hours,omitempty"`
+	VserverSubtype             string   `xml:"vserver-subtype,omitempty"`
 }
 
 type VServerQuery struct {
@@ -70,10 +63,8 @@ type VServerListResponse struct {
 type VServerResponse struct {
 	XMLName xml.Name `xml:"netapp"`
 	Results struct {
-		ResultBase
-		AttributesList struct {
-			VserverInfo []VServerInfo `xml:"vserver-info"`
-		} `xml:"attributes"`
+		SingleResultBase
+		VServerInfo VServerInfo `xml:"attributes>vserver-info"`
 	} `xml:"results"`
 }
 


### PR DESCRIPTION
This PR adds a bunch of stuff and has some breaking changes due to how "nested" structs were being marshaled, IMO, this way is much better, but its up to you to decide :)

I also added Volume Modify and volume operations (Create, set offline, unmount, destroy, etc).

In Volume, changed a bunch:
* added `VolumeQosAttributes`
* added a bunch of `omitempty`s
* Switched `VolumeInfo` to pointers instead of direct so that `Query` requests do not break
* Added `SingleBaseResult` as I was running into a lot of those.
* adjusted a few types to reflect whats in the API.