### PR TITLE
add vserver exports rule, nfs service, creating vserver

### DIFF
--- a/netapp/base.go
+++ b/netapp/base.go
@@ -16,7 +16,7 @@ type Base struct {
 type ResultBase struct {
 	Status     string `xml:"status,attr"`
 	Reason     string `xml:"reason,attr"`
-	NumRecords int    `json:"num-records"`
+	NumRecords int    `xml:"num-records"`
 	ErrorNo    int    `xml:"errno,attr"`
 }
 
@@ -26,11 +26,23 @@ type SingleResultBase struct {
 	ErrorNo int    `xml:"errno,attr"`
 }
 
+type AsyncResultBase struct {
+	ErrorCode    int    `xml:"result-error-code"`
+	ErrorMessage string `xml:"result-error-message"`
+	JobID        int    `xml:"result-jobid"`
+	JobStatus    string `xml:"result-status"`
+	Status       string `xml:"status,attr"`
+}
+
 func (r *ResultBase) Passed() bool {
 	return r.Status == "passed"
 }
 
 func (r *SingleResultBase) Passed() bool {
+	return r.Status == "passed"
+}
+
+func (r *AsyncResultBase) Passed() bool {
 	return r.Status == "passed"
 }
 

--- a/netapp/base.go
+++ b/netapp/base.go
@@ -26,6 +26,14 @@ type SingleResultBase struct {
 	ErrorNo int    `xml:"errno,attr"`
 }
 
+// SingleResultResponse is used any time only pass/error is communted back to the client from the server
+type SingleResultResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+	} `xml:"results"`
+}
+
 type AsyncResultBase struct {
 	ErrorCode    int    `xml:"result-error-code"`
 	ErrorMessage string `xml:"result-error-message"`

--- a/netapp/fixtures/TestVServer_CreateSuccess_request.xml
+++ b/netapp/fixtures/TestVServer_CreateSuccess_request.xml
@@ -1,0 +1,12 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <vserver-create-async>
+    <ipspace>g554</ipspace>
+    <snapshot-policy>none</snapshot-policy>
+    <vserver-name>G554</vserver-name>
+    <language>C.UTF-8</language>
+    <root-volume>g554_root</root-volume>
+    <root-volume-aggregate>test_aggr_01</root-volume-aggregate>
+    <root-volume-security-style>unix</root-volume-security-style>
+    <vserver-subtype>default</vserver-subtype>
+  </vserver-create-async>
+</netapp>

--- a/netapp/fixtures/TestVServer_CreateSuccess_response.xml
+++ b/netapp/fixtures/TestVServer_CreateSuccess_response.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of vserver-create-async [Execution Time: 203 ms] -->
+	<results status='passed'>
+		<result>
+			<vserver-info>
+				<vserver-name>G554</vserver-name>
+			</vserver-info>
+		</result>
+		<result-jobid>27008</result-jobid>
+		<result-status>in_progress</result-status>
+	</results>
+</netapp>
+<?xml version="1.0" encoding="UTF-8"?>

--- a/netapp/fixtures/TestVServer_ExportsRuleCreateSuccess_request.xml
+++ b/netapp/fixtures/TestVServer_ExportsRuleCreateSuccess_request.xml
@@ -1,0 +1,20 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="C666">
+  <export-rule-create>
+    <client-match>0.0.0.0/0</client-match>
+    <is-allow-dev-is-enabled>true</is-allow-dev-is-enabled>
+    <is-allow-set-uid-enabled>true</is-allow-set-uid-enabled>
+    <policy-name>default</policy-name>
+    <protocol>
+      <access-protocol>any</access-protocol>
+    </protocol>
+    <ro-rule>
+      <security-flavor>any</security-flavor>
+    </ro-rule>
+    <rw-rule>
+      <security-flavor>any</security-flavor>
+    </rw-rule>
+    <super-user-security>
+      <security-flavor>any</security-flavor>
+    </super-user-security>
+  </export-rule-create>
+</netapp>

--- a/netapp/fixtures/TestVServer_ExportsRuleCreateSuccess_response.xml
+++ b/netapp/fixtures/TestVServer_ExportsRuleCreateSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of export-rule-create [Execution Time: 246 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/fixtures/TestVServer_ExportsRuleDeleteSuccess_request.xml
+++ b/netapp/fixtures/TestVServer_ExportsRuleDeleteSuccess_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="C666">
+  <export-rule-destroy>
+    <policy-name>default</policy-name>
+    <rule-index>1</rule-index>
+  </export-rule-destroy>
+</netapp>

--- a/netapp/fixtures/TestVServer_ExportsRuleDeleteSuccess_response.xml
+++ b/netapp/fixtures/TestVServer_ExportsRuleDeleteSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of export-rule-destroy [Execution Time: 160 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/fixtures/TestVServer_GetFailure_request.xml
+++ b/netapp/fixtures/TestVServer_GetFailure_request.xml
@@ -1,0 +1,3 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="non-existent-vserver">
+  <vserver-get></vserver-get>
+</netapp>

--- a/netapp/fixtures/TestVServer_GetFailure_response.xml
+++ b/netapp/fixtures/TestVServer_GetFailure_response.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE netapp SYSTEM 'file:/etc/netapp_gx.dtd'>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+<results reason="Specified vserver not found" status="failed" errno="15698"/></netapp>

--- a/netapp/fixtures/TestVServer_GetSuccess_request.xml
+++ b/netapp/fixtures/TestVServer_GetSuccess_request.xml
@@ -1,0 +1,3 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="G555">
+  <vserver-get></vserver-get>
+</netapp>

--- a/netapp/fixtures/TestVServer_GetSuccess_response.xml
+++ b/netapp/fixtures/TestVServer_GetSuccess_response.xml
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of vserver-get [Execution Time: 245 ms] -->
+	<results status='passed'>
+		<attributes>
+			<vserver-info>
+				<aggr-list>
+					<aggr-name>aggr0_root_cluster01_01</aggr-name>
+					<aggr-name>aggr0_root_cluster01_02</aggr-name>
+					<aggr-name>n01_aggrfp_sas01</aggr-name>
+					<aggr-name>n02_aggr_sata01</aggr-name>
+				</aggr-list>
+				<allowed-protocols>
+					<protocol>nfs</protocol>
+				</allowed-protocols>
+				<antivirus-on-access-policy>default</antivirus-on-access-policy>
+				<comment/>
+				<disallowed-protocols>
+					<protocol>cifs</protocol>
+					<protocol>fcp</protocol>
+					<protocol>iscsi</protocol>
+					<protocol>ndmp</protocol>
+				</disallowed-protocols>
+				<ipspace>g555</ipspace>
+				<is-config-locked-for-changes>false</is-config-locked-for-changes>
+				<is-repository-vserver>false</is-repository-vserver>
+				<language>c.utf_8</language>
+				<max-volumes>unlimited</max-volumes>
+				<name-mapping-switch>
+					<nmswitch>file</nmswitch>
+				</name-mapping-switch>
+				<name-server-switch>
+					<nsswitch>file</nsswitch>
+				</name-server-switch>
+				<operational-state>running</operational-state>
+				<quota-policy>default</quota-policy>
+				<root-volume>g555_root</root-volume>
+				<root-volume-aggregate>n01_aggrfp_sas01</root-volume-aggregate>
+				<root-volume-security-style>unix</root-volume-security-style>
+				<snapshot-policy>none</snapshot-policy>
+				<state>running</state>
+				<uuid>48fc46c1-9b2e-11e8-bf6a-00a0983afb38</uuid>
+				<volume-delete-retention-hours>0</volume-delete-retention-hours>
+				<vserver-aggr-info-list>
+					<vserver-aggr-info>
+						<aggr-availsize>18352828416</aggr-availsize>
+						<aggr-is-cft-precommit>false</aggr-is-cft-precommit>
+						<aggr-name>aggr0_root_cluster01_01</aggr-name>
+					</vserver-aggr-info>
+					<vserver-aggr-info>
+						<aggr-availsize>74439512064</aggr-availsize>
+						<aggr-is-cft-precommit>false</aggr-is-cft-precommit>
+						<aggr-name>aggr0_root_cluster01_02</aggr-name>
+					</vserver-aggr-info>
+					<vserver-aggr-info>
+						<aggr-availsize>4775117905920</aggr-availsize>
+						<aggr-is-cft-precommit>false</aggr-is-cft-precommit>
+						<aggr-name>n01_aggrfp_sas01</aggr-name>
+					</vserver-aggr-info>
+					<vserver-aggr-info>
+						<aggr-availsize>9783342731264</aggr-availsize>
+						<aggr-is-cft-precommit>false</aggr-is-cft-precommit>
+						<aggr-name>n02_aggr_sata01</aggr-name>
+					</vserver-aggr-info>
+				</vserver-aggr-info-list>
+				<vserver-name>G555</vserver-name>
+				<vserver-subtype>default</vserver-subtype>
+				<vserver-type>data</vserver-type>
+			</vserver-info>
+		</attributes>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestVServer_NfsCreateSuccess_request.xml
+++ b/netapp/fixtures/TestVServer_NfsCreateSuccess_request.xml
@@ -1,0 +1,8 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="C666">
+  <nfs-service-create>
+    <is-nfs-access-enabled>true</is-nfs-access-enabled>
+    <is-nfsv3-enabled>true</is-nfsv3-enabled>
+    <is-nfsv40-enabled>true</is-nfsv40-enabled>
+    <is-vstorage-enabled>true</is-vstorage-enabled>
+  </nfs-service-create>
+</netapp>

--- a/netapp/fixtures/TestVServer_NfsCreateSuccess_response.xml
+++ b/netapp/fixtures/TestVServer_NfsCreateSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of nfs-service-create [Execution Time: 216 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/netapp_test.go
+++ b/netapp/netapp_test.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/andreyvit/diff"
@@ -19,7 +21,11 @@ func setup() (baseURL string, mux *http.ServeMux, teardownFn func()) {
 }
 
 func fixture(path string, t *testing.T) []byte {
-	b, err := ioutil.ReadFile("fixtures/" + path)
+	r, err := os.OpenFile("fixtures/"+path, os.O_RDONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,4 +58,52 @@ func createTestClientWithFixtures(t *testing.T) (c *netapp.Client, teardownFn fu
 	c = netapp.NewClient(baseURL, "1.10", nil)
 
 	return c, teardown
+}
+
+func checkResponseSuccess(result *netapp.SingleResultBase, err error, t *testing.T) {
+	if err != nil {
+		t.Fatalf("Should not have gotten an error %s", err)
+	}
+
+	if !result.Passed() {
+		t.Fatalf("Got the failure response, expected success, reason: %s", result.Reason)
+	}
+}
+
+func checkAsyncResponseSuccess(result *netapp.AsyncResultBase, err error, t *testing.T) {
+	if err != nil {
+		t.Fatalf("Async Response should not have gotten an error %s", err)
+	}
+
+	if !result.Passed() {
+		t.Fatalf("Async Response expected success got failure, reason: %s", result.ErrorMessage)
+	}
+}
+
+func checkResponseFailure(result *netapp.SingleResultBase, err error, t *testing.T) {
+	if err != nil {
+		t.Fatalf("Should not have gotten an error %s", err)
+	}
+
+	if result.Passed() {
+		t.Fatal("Got the successful response, expecting failure")
+	}
+}
+
+func testFailureResult(errorNo int, reason string, result *netapp.SingleResultBase, t *testing.T) {
+
+	if result.ErrorNo != errorNo {
+		t.Errorf("%s got = %+v, want %+v", t.Name(), result.ErrorNo, errorNo)
+	}
+
+	if result.Reason != reason {
+		t.Errorf("%s got = %+v, want %+v", t.Name(), result.Reason, reason)
+	}
+}
+
+// debugTableItems is used to get reflected vaules of 2 items so its easier to tell why reflect.DeepEqual() fails
+func debugItems(v1 interface{}, v2 interface{}) {
+	val1 := reflect.ValueOf(v1)
+	val2 := reflect.ValueOf(v2)
+	fmt.Printf("v1: %v, v2: %v", val1, val2)
 }

--- a/netapp/qos-policy_test.go
+++ b/netapp/qos-policy_test.go
@@ -6,38 +6,6 @@ import (
 	"github.com/pepabo/go-netapp/netapp"
 )
 
-func checkResponseSuccess(result *netapp.SingleResultBase, err error, t *testing.T) {
-
-	if err != nil {
-		t.Fatalf("Should not have gotten an error %s", err)
-	}
-
-	if !result.Passed() {
-		t.Fatalf("Got the failure response, expected success, reason: %s", result.Reason)
-	}
-}
-
-func checkResponseFailure(result *netapp.SingleResultBase, err error, t *testing.T) {
-	if err != nil {
-		t.Fatalf("Should not have gotten an error %s", err)
-	}
-
-	if result.Passed() {
-		t.Fatal("Got the successful response, expecting failure")
-	}
-}
-
-func testFailureResult(errorNo int, reason string, result *netapp.SingleResultBase, t *testing.T) {
-
-	if result.ErrorNo != errorNo {
-		t.Errorf("%s got = %+v, want %+v", t.Name(), result.ErrorNo, errorNo)
-	}
-
-	if result.Reason != reason {
-		t.Errorf("%s got = %+v, want %+v", t.Name(), result.Reason, reason)
-	}
-}
-
 func TestQosPolicy_GetSuccess(t *testing.T) {
 	c, teardown := createTestClientWithFixtures(t)
 	defer teardown()

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -1,0 +1,71 @@
+package netapp
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+type vServerExportsRequest struct {
+	Base
+	Params struct {
+		XMLName               xml.Name
+		VServerExportRuleInfo `xml:",innerxml"`
+	}
+}
+
+// VServerExportRuleInfo sets all different options for Export Rules
+type VServerExportRuleInfo struct {
+	AnonymousUserID           int       `xml:"anonymous-user-id,omitempty"`
+	ClientMatch               string    `xml:"client-match,omitempty"`
+	ExportChownMode           string    `xml:"export-chown-mode,omitempty"`
+	ExportNTFSUnixSecurityOps string    `xml:"export-ntfs-unix-security-ops,omitempty"`
+	AllowCreateDevices        bool      `xml:"is-allow-dev-is-enabled,omitempty"`
+	AllowSetUID               bool      `xml:"is-allow-set-uid-enabled,omitempty"`
+	PolicyName                string    `xml:"policy-name,omitempty"`
+	Protocol                  *[]string `xml:"protocol>access-protocol,omitempty"`
+	ReadOnlyRule              *[]string `xml:"ro-rule>security-flavor,omitempty"`
+	RuleIndex                 int       `xml:"rule-index,omitempty"`
+	ReadWriteRule             *[]string `xml:"rw-rule>security-flavor,omitempty"`
+	SuperUserSecurity         *[]string `xml:"super-user-security>security-flavor,omitempty"`
+}
+
+// VServerExportsResponse creates correct response obj
+type VServerExportsResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+	} `xml:"results"`
+}
+
+// CreateExportRule creates a new export rule for a given vserver
+func (v VServer) CreateExportRule(vServerName string, options *VServerExportRuleInfo) (*VServerExportsResponse, *http.Response, error) {
+	req := v.newVServerExportsRequest()
+	req.Base.Name = vServerName
+	req.Params.XMLName = xml.Name{Local: "export-rule-create"}
+	req.Params.VServerExportRuleInfo = *options
+
+	r := &VServerExportsResponse{}
+	res, err := v.get(req, r)
+	return r, res, err
+}
+
+// DeleteExportRule removes an export rule for a given vserver, policy and rule index
+func (v VServer) DeleteExportRule(vServerName string, policyName string, ruleIndex int) (*VServerExportsResponse, *http.Response, error) {
+	req := v.newVServerExportsRequest()
+	req.Base.Name = vServerName
+	req.Params.XMLName = xml.Name{Local: "export-rule-destroy"}
+	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{
+		PolicyName: policyName,
+		RuleIndex:  ruleIndex,
+	}
+
+	r := &VServerExportsResponse{}
+	res, err := v.get(req, r)
+	return r, res, err
+}
+
+func (v VServer) newVServerExportsRequest() *vServerExportsRequest {
+	return &vServerExportsRequest{
+		Base: v.Base,
+	}
+}

--- a/netapp/vserver-exports_test.go
+++ b/netapp/vserver-exports_test.go
@@ -1,0 +1,36 @@
+package netapp_test
+
+import (
+	"testing"
+
+	"github.com/pepabo/go-netapp/netapp"
+)
+
+func TestVServer_ExportsRuleCreateSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	opts := &netapp.VServerExportRuleInfo{
+		PolicyName:         "default",
+		SuperUserSecurity:  &[]string{"any"},
+		Protocol:           &[]string{"any"},
+		AllowSetUID:        true,
+		AllowCreateDevices: true,
+		ClientMatch:        "0.0.0.0/0",
+		ReadWriteRule:      &[]string{"any"},
+		ReadOnlyRule:       &[]string{"any"},
+	}
+
+	call, _, err := c.VServer.CreateExportRule("C666", opts)
+
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}
+
+func TestVServer_ExportsRuleDeleteSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.VServer.DeleteExportRule("C666", "default", 1)
+
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}

--- a/netapp/vserver-nfs.go
+++ b/netapp/vserver-nfs.go
@@ -1,0 +1,39 @@
+package netapp
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+type vServerNfsRequest struct {
+	Base
+	Params struct {
+		XMLName                 xml.Name
+		VServerNfsCreateOptions `xml:",innerxml"`
+	}
+}
+
+type VServerNfsCreateOptions struct {
+	NfsAccessEnabled bool `xml:"is-nfs-access-enabled"`
+	NfsV3Enabled     bool `xml:"is-nfsv3-enabled"`
+	NfsV4Enabled     bool `xml:"is-nfsv40-enabled"`
+	VStorageEnabled  bool `xml:"is-vstorage-enabled"`
+}
+
+// CreateNfsService configures and enables nfs service on a vserver
+func (v VServer) CreateNfsService(vServerName string, options *VServerNfsCreateOptions) (*SingleResultResponse, *http.Response, error) {
+	req := v.newVServerNfsRequest()
+	req.Base.Name = vServerName
+	req.Params.XMLName = xml.Name{Local: "nfs-service-create"}
+	req.Params.VServerNfsCreateOptions = *options
+
+	r := &SingleResultResponse{}
+	res, err := v.get(req, r)
+	return r, res, err
+}
+
+func (v VServer) newVServerNfsRequest() *vServerNfsRequest {
+	return &vServerNfsRequest{
+		Base: v.Base,
+	}
+}

--- a/netapp/vserver-nfs_test.go
+++ b/netapp/vserver-nfs_test.go
@@ -1,0 +1,23 @@
+package netapp_test
+
+import (
+	"testing"
+
+	"github.com/pepabo/go-netapp/netapp"
+)
+
+func TestVServer_NfsCreateSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	nfsOpts := &netapp.VServerNfsCreateOptions{
+		NfsAccessEnabled: true,
+		NfsV3Enabled:     true,
+		NfsV4Enabled:     true,
+		VStorageEnabled:  true,
+	}
+
+	call, _, err := c.VServer.CreateNfsService("C666", nfsOpts)
+
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}

--- a/netapp/vserver.go
+++ b/netapp/vserver.go
@@ -8,36 +8,37 @@ import (
 type VServer struct {
 	Base
 	Params struct {
-		XMLName xml.Name
-		*VServerOptions
+		XMLName     xml.Name
+		VServerInfo `xml:",innerxml"`
+		VServerOptions
 	}
 }
 
 type VServerInfo struct {
-	AntivirusOnAccessPolicy    string   `xml:"antivirus-on-access-policy,omitempty"`
-	AggregateList              []string `xml:"aggr-list>aggr-name"`
-	Comment                    string   `xml:"comment,omitempty"`
-	Ipspace                    string   `xml:"ipspace,omitempty"`
-	IsRepositoryVserver        string   `xml:"is-repository-vserver,omitempty"`
-	SnapshotPolicy             string   `xml:"snapshot-policy,omitempty"`
-	UUID                       string   `xml:"uuid,omitempty"`
-	VserverName                string   `xml:"vserver-name,omitempty"`
-	VserverType                string   `xml:"vserver-type,omitempty"`
-	AllowedProtocols           []string `xml:"allowed-protocols>protocol,omitempty"`
-	DisallowedProtocols        []string `xml:"disallowed-protocols>protocol,omitempty"`
-	IsConfigLockedForChanges   string   `xml:"is-config-locked-for-changes,omitempty"`
-	Language                   string   `xml:"language,omitempty"`
-	MaxVolumes                 string   `xml:"max-volumes,omitempty"`
-	NameMappingSwitch          []string `xml:"name-mapping-switch>nmswitch,omitempty"`
-	NameServerSwitch           []string `xml:"name-server-switch>nsswitch,omitempty"`
-	OperationalState           string   `xml:"operational-state,omitempty"`
-	QuotaPolicy                string   `xml:"quota-policy,omitempty"`
-	RootVolume                 string   `xml:"root-volume,omitempty"`
-	RootVolumeAggregate        string   `xml:"root-volume-aggregate,omitempty"`
-	RootVolumeSecurityStyle    string   `xml:"root-volume-security-style,omitempty"`
-	State                      string   `xml:"state,omitempty"`
-	VolumeDeleteRetentionHours int      `xml:"volume-delete-retention-hours,omitempty"`
-	VserverSubtype             string   `xml:"vserver-subtype,omitempty"`
+	AntivirusOnAccessPolicy    string    `xml:"antivirus-on-access-policy,omitempty"`
+	AggregateList              *[]string `xml:"aggr-list>aggr-name"`
+	Comment                    string    `xml:"comment,omitempty"`
+	Ipspace                    string    `xml:"ipspace,omitempty"`
+	IsRepositoryVserver        string    `xml:"is-repository-vserver,omitempty"`
+	SnapshotPolicy             string    `xml:"snapshot-policy,omitempty"`
+	UUID                       string    `xml:"uuid,omitempty"`
+	VserverName                string    `xml:"vserver-name,omitempty"`
+	VserverType                string    `xml:"vserver-type,omitempty"`
+	AllowedProtocols           *[]string `xml:"allowed-protocols>protocol,omitempty"`
+	DisallowedProtocols        *[]string `xml:"disallowed-protocols>protocol,omitempty"`
+	IsConfigLockedForChanges   bool      `xml:"is-config-locked-for-changes,omitempty"`
+	Language                   string    `xml:"language,omitempty"`
+	MaxVolumes                 string    `xml:"max-volumes,omitempty"`
+	NameMappingSwitch          *[]string `xml:"name-mapping-switch>nmswitch,omitempty"`
+	NameServerSwitch           *[]string `xml:"name-server-switch>nsswitch,omitempty"`
+	OperationalState           string    `xml:"operational-state,omitempty"`
+	QuotaPolicy                string    `xml:"quota-policy,omitempty"`
+	RootVolume                 string    `xml:"root-volume,omitempty"`
+	RootVolumeAggregate        string    `xml:"root-volume-aggregate,omitempty"`
+	RootVolumeSecurityStyle    string    `xml:"root-volume-security-style,omitempty"`
+	State                      string    `xml:"state,omitempty"`
+	VolumeDeleteRetentionHours int       `xml:"volume-delete-retention-hours,omitempty"`
+	VserverSubtype             string    `xml:"vserver-subtype,omitempty"`
 }
 
 type VServerQuery struct {
@@ -68,18 +69,43 @@ type VServerResponse struct {
 	} `xml:"results"`
 }
 
-func (v *VServer) Get(name string, options *VServerOptions) (*VServerResponse, *http.Response, error) {
+// VServerAsyncResponse returns job-based responses
+type VServerAsyncResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		AsyncResultBase
+		VServerInfo VServerInfo `xml:"result>vserver-info"`
+	} `xml:"results"`
+}
+
+// Create creates a new VServer
+func (v VServer) Create(options *VServerInfo) (*VServerAsyncResponse, *http.Response, error) {
+	v.Params.XMLName = xml.Name{Local: "vserver-create-async"}
+	v.Params.VServerInfo = *options
+	r := VServerAsyncResponse{}
+	res, err := v.get(v, &r)
+	return &r, res, err
+}
+
+func (v VServer) Get(name string, options *VServerOptions) (*VServerResponse, *http.Response, error) {
 	v.Name = name
 	v.Params.XMLName = xml.Name{Local: "vserver-get"}
-	v.Params.VServerOptions = options
+	v.Params.VServerOptions = *options
 	r := VServerResponse{}
 	res, err := v.get(v, &r)
 	return &r, res, err
 }
 
-func (v *VServer) List(options *VServerOptions) (*VServerListResponse, *http.Response, error) {
+func (v VServer) List(options *VServerOptions) (*VServerListResponse, *http.Response, error) {
 	v.Params.XMLName = xml.Name{Local: "vserver-get-iter"}
-	v.Params.VServerOptions = options
+	v.Params.VServerOptions = *options
+
+	r := VServerListResponse{}
+	res, err := v.get(v, &r)
+	return &r, res, err
+}
+
+func (v VServer) Delete(name string) (*VServerListResponse, *http.Response, error) {
 
 	r := VServerListResponse{}
 	res, err := v.get(v, &r)

--- a/netapp/vserver_test.go
+++ b/netapp/vserver_test.go
@@ -1,0 +1,96 @@
+package netapp_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pepabo/go-netapp/netapp"
+)
+
+func TestVServer_GetSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.VServer.Get("G555", &netapp.VServerOptions{})
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+
+	info := call.Results.VServerInfo
+
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"Aggregate List", info.AggregateList, &[]string{
+			"aggr0_root_cluster01_01",
+			"aggr0_root_cluster01_02",
+			"n01_aggrfp_sas01",
+			"n02_aggr_sata01",
+		}},
+		{"Allowed Protocols", info.AllowedProtocols, &[]string{"nfs"}},
+		{"Anti Virus on Access Policy", info.AntivirusOnAccessPolicy, "default"},
+		{"Disallowed Protocols", info.DisallowedProtocols, &[]string{"cifs", "fcp", "iscsi", "ndmp"}},
+		{"Ip Space", info.Ipspace, "g555"},
+		{"Is locked for changes", info.IsConfigLockedForChanges, false},
+		{"Language", info.Language, "c.utf_8"},
+		{"Max volumes", info.MaxVolumes, "unlimited"},
+		{"Operational State", info.OperationalState, "running"},
+		{"Quota Policy", info.QuotaPolicy, "default"},
+		{"Root Volume", info.RootVolume, "g555_root"},
+		{"Root Volume Aggregate", info.RootVolumeAggregate, "n01_aggrfp_sas01"},
+		{"Vserver Name", info.VserverName, "G555"},
+		{"UUID", info.UUID, "48fc46c1-9b2e-11e8-bf6a-00a0983afb38"},
+		{"Vserver Type", info.VserverType, "data"},
+		{"Vserver Subtype", info.VserverSubtype, "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Errorf("Vserver.Get() got = %+v, want %+v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVServer_GetFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.VServer.Get("non-existent-vserver", &netapp.VServerOptions{})
+
+	results := &call.Results.SingleResultBase
+	checkResponseFailure(results, err, t)
+
+	testFailureResult(15698, "Specified vserver not found", results, t)
+}
+
+func TestVServer_CreateSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	vserverSettings := &netapp.VServerInfo{
+		VserverName:             "G554",
+		VserverSubtype:          "default",
+		RootVolume:              "g554_root",
+		RootVolumeSecurityStyle: "unix",
+		RootVolumeAggregate:     "test_aggr_01",
+		SnapshotPolicy:          "none",
+		Language:                "C.UTF-8",
+		Ipspace:                 "g554",
+	}
+
+	call, _, err := c.VServer.Create(vserverSettings)
+	checkAsyncResponseSuccess(&call.Results.AsyncResultBase, err, t)
+
+	info := call.Results.VServerInfo
+	job := call.Results.AsyncResultBase
+	expectedJob := 27008
+	if job.JobID != expectedJob {
+		t.Errorf("Incorrect Job Id. Expected %d, got %d", expectedJob, job.JobID)
+	}
+	// checkJobResponse(job.JobID, 27008)
+	if info.VserverName != vserverSettings.VserverName {
+		t.Errorf("Incorrect VServer name. Expected %s, got %s", vserverSettings.VserverName, info.VserverName)
+	}
+}


### PR DESCRIPTION
This PR adds the following calls:

- `VServer.CreateExportRule`
- `VServer.DeleteExportRule`
- `VServer.CreateNfsService`
- `VServer.Create`

Also added a VServer GET test as well as `AsyncResultBase` for any `async` type calls