### PR TITLE
Add a bunch of net* calls

### DIFF
--- a/netapp/base.go
+++ b/netapp/base.go
@@ -13,6 +13,11 @@ type Base struct {
 	client  *Client
 }
 
+type Result interface {
+	Passed() bool
+	Result() *SingleResultBase
+}
+
 type ResultBase struct {
 	Status     string `xml:"status,attr"`
 	Reason     string `xml:"reason,attr"`
@@ -46,12 +51,32 @@ func (r *ResultBase) Passed() bool {
 	return r.Status == "passed"
 }
 
+func (r *ResultBase) Result() *SingleResultBase {
+	return &SingleResultBase{
+		Status:  r.Status,
+		Reason:  r.Reason,
+		ErrorNo: r.ErrorNo,
+	}
+}
+
 func (r *SingleResultBase) Passed() bool {
 	return r.Status == "passed"
 }
 
+func (r *SingleResultBase) Result() *SingleResultBase {
+	return r
+}
+
 func (r *AsyncResultBase) Passed() bool {
 	return r.Status == "passed"
+}
+
+func (r *AsyncResultBase) Result() *SingleResultBase {
+	return &SingleResultBase{
+		Status:  r.Status,
+		Reason:  r.ErrorMessage,
+		ErrorNo: r.ErrorCode,
+	}
 }
 
 func (b *Base) get(base interface{}, r interface{}) (*http.Response, error) {

--- a/netapp/base.go
+++ b/netapp/base.go
@@ -26,6 +26,22 @@ type SingleResultBase struct {
 	ErrorNo int    `xml:"errno,attr"`
 }
 
+// SingleResultResponse is used any time only pass/error is communted back to the client from the server
+type SingleResultResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+	} `xml:"results"`
+}
+
+type AsyncResultBase struct {
+	ErrorCode    int    `xml:"result-error-code"`
+	ErrorMessage string `xml:"result-error-message"`
+	JobID        int    `xml:"result-jobid"`
+	JobStatus    string `xml:"result-status"`
+	Status       string `xml:"status,attr"`
+}
+
 func (r *ResultBase) Passed() bool {
 	return r.Status == "passed"
 }

--- a/netapp/fixtures/TestNet_BroadcastDomainCreateFailure_request.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainCreateFailure_request.xml
@@ -1,0 +1,7 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-port-broadcast-domain-create>
+    <broadcast-domain>test-bcastdomain</broadcast-domain>
+    <ipspace>test-ip-space</ipspace>
+    <mtu>1500</mtu>
+  </net-port-broadcast-domain-create>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainCreateFailure_response.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainCreateFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-port-broadcast-domain-create [Execution Time: 156 ms] -->
+	<results reason='Specified IPspace not found' errno='18603' status='failed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainCreateSuccess_request.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainCreateSuccess_request.xml
@@ -1,0 +1,11 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-port-broadcast-domain-create>
+    <broadcast-domain>test-bcastdomain</broadcast-domain>
+    <ipspace>test-ip-space</ipspace>
+    <mtu>1500</mtu>
+    <ports>
+      <net-qualified-port-name>lab-cluster01-01:a0a-3555</net-qualified-port-name>
+      <net-qualified-port-name>lab-cluster01-02:a0a-3555</net-qualified-port-name>
+    </ports>
+  </net-port-broadcast-domain-create>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainCreateSuccess_response.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainCreateSuccess_response.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-port-broadcast-domain-create [Execution Time: 308 ms] -->
+	<results status='passed'>
+		<port-update-status-combined>complete</port-update-status-combined>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainDeleteFailure_request.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainDeleteFailure_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-port-broadcast-domain-destroy>
+    <broadcast-domain>test-bcastdomain</broadcast-domain>
+    <ipspace>test-ip-space</ipspace>
+  </net-port-broadcast-domain-destroy>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainDeleteFailure_response.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainDeleteFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-port-broadcast-domain-destroy [Execution Time: 246 ms] -->
+	<results reason='Broadcast domain "test-bcastdomain" in IPspace "test-ip-space" not found.' errno='18604' status='failed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainDeleteSuccess_request.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainDeleteSuccess_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-port-broadcast-domain-destroy>
+    <broadcast-domain>test-bcastdomain</broadcast-domain>
+    <ipspace>test-ip-space</ipspace>
+  </net-port-broadcast-domain-destroy>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainDeleteSuccess_response.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainDeleteSuccess_response.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-port-broadcast-domain-destroy [Execution Time: 156 ms] -->
+	<results status='passed'>
+		<port-update-status-combined>complete</port-update-status-combined>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainGetFailure_request.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainGetFailure_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-port-broadcast-domain-get>
+    <broadcast-domain>other-bdomain</broadcast-domain>
+    <ipspace>test-ip-space</ipspace>
+  </net-port-broadcast-domain-get>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainGetFailure_response.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainGetFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-port-broadcast-domain-get [Execution Time: 150 ms] -->
+	<results reason='entry doesn"t exist' errno='15661' status='failed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainGetSuccess_request.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainGetSuccess_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-port-broadcast-domain-get>
+    <broadcast-domain>test-bdomain</broadcast-domain>
+    <ipspace>test-net-ipspace</ipspace>
+  </net-port-broadcast-domain-get>
+</netapp>

--- a/netapp/fixtures/TestNet_BroadcastDomainGetSuccess_response.xml
+++ b/netapp/fixtures/TestNet_BroadcastDomainGetSuccess_response.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-port-broadcast-domain-get [Execution Time: 271 ms] -->
+	<results status='passed'>
+		<attributes>
+			<net-port-broadcast-domain-info>
+				<broadcast-domain>test-bdomain</broadcast-domain>
+				<failover-groups>
+					<failover-group>test-bdomain</failover-group>
+				</failover-groups>
+				<ipspace>test-net-ipspace</ipspace>
+				<mtu>1500</mtu>
+				<port-update-status-combined>complete</port-update-status-combined>
+				<ports>
+					<port-info>
+						<port>lab-cluster01-02:a0a-3555</port>
+						<port-update-status>complete</port-update-status>
+						<port-update-status-details>complete</port-update-status-details>
+					</port-info>
+					<port-info>
+						<port>lab-cluster01-01:a0a-3555</port>
+						<port-update-status>complete</port-update-status>
+						<port-update-status-details>complete</port-update-status-details>
+					</port-info>
+				</ports>
+			</net-port-broadcast-domain-info>
+		</attributes>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceCreateFailure_request.xml
+++ b/netapp/fixtures/TestNet_IPSpaceCreateFailure_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-ipspaces-create>
+    <ipspace>test-ip-space</ipspace>
+    <return-record>false</return-record>
+  </net-ipspaces-create>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceCreateFailure_response.xml
+++ b/netapp/fixtures/TestNet_IPSpaceCreateFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-ipspaces-create [Execution Time: 167 ms] -->
+	<results reason='Invalid IPspace name. The name "test-ip-space" is already in use by a cluster node, Vserver, or is the name of the local cluster.' errno='13001' status='failed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceCreateSuccess_request.xml
+++ b/netapp/fixtures/TestNet_IPSpaceCreateSuccess_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-ipspaces-create>
+    <ipspace>test-ip-space</ipspace>
+    <return-record>true</return-record>
+  </net-ipspaces-create>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceCreateSuccess_response.xml
+++ b/netapp/fixtures/TestNet_IPSpaceCreateSuccess_response.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-ipspaces-create [Execution Time: 328 ms] -->
+	<results status='passed'>
+		<result>
+			<net-ipspaces-info>
+				<id>39</id>
+				<ipspace>test-ip-space</ipspace>
+				<uuid>af9fa457-c02d-11e8-bf6a-00a0983afb38</uuid>
+				<vservers>
+					<vserver-name>test-ip-space</vserver-name>
+				</vservers>
+			</net-ipspaces-info>
+		</result>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceDeleteFailure_request.xml
+++ b/netapp/fixtures/TestNet_IPSpaceDeleteFailure_request.xml
@@ -1,0 +1,5 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-ipspaces-destroy>
+    <ipspace>test-net-ipspace-new</ipspace>
+  </net-ipspaces-destroy>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceDeleteFailure_response.xml
+++ b/netapp/fixtures/TestNet_IPSpaceDeleteFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-ipspaces-destroy [Execution Time: 144 ms] -->
+	<results reason='entry doesn"t exist' errno='15661' status='failed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceDeleteSuccess_request.xml
+++ b/netapp/fixtures/TestNet_IPSpaceDeleteSuccess_request.xml
@@ -1,0 +1,5 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-ipspaces-destroy>
+    <ipspace>test-net-ipspace-new</ipspace>
+  </net-ipspaces-destroy>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceDeleteSuccess_response.xml
+++ b/netapp/fixtures/TestNet_IPSpaceDeleteSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-ipspaces-destroy [Execution Time: 355 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceGetFailure_request.xml
+++ b/netapp/fixtures/TestNet_IPSpaceGetFailure_request.xml
@@ -1,0 +1,5 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-ipspaces-get>
+    <ipspace>test-ip-space</ipspace>
+  </net-ipspaces-get>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceGetFailure_response.xml
+++ b/netapp/fixtures/TestNet_IPSpaceGetFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-ipspaces-get [Execution Time: 165 ms] -->
+	<results reason='entry doesn"t exist' errno='15661' status='failed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceGetSuccess_request.xml
+++ b/netapp/fixtures/TestNet_IPSpaceGetSuccess_request.xml
@@ -1,0 +1,5 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-ipspaces-get>
+    <ipspace>test-net-ipspace</ipspace>
+  </net-ipspaces-get>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceGetSuccess_response.xml
+++ b/netapp/fixtures/TestNet_IPSpaceGetSuccess_response.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-ipspaces-get [Execution Time: 248 ms] -->
+	<results status='passed'>
+		<broadcast-domains>
+			<broadcast-domain-name>test-net-ipspace</broadcast-domain-name>
+		</broadcast-domains>
+		<ports>
+			<net-qualified-port-name>lab-cluster01-02:a0a-3555</net-qualified-port-name>
+			<net-qualified-port-name>lab-cluster01-01:a0a-3555</net-qualified-port-name>
+		</ports>
+		<vservers>
+			<vserver-name>Test-Vserver</vserver-name>
+			<vserver-name>test-vserver</vserver-name>
+		</vservers>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceListSuccess_request.xml
+++ b/netapp/fixtures/TestNet_IPSpaceListSuccess_request.xml
@@ -1,0 +1,10 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-ipspaces-get-iter>
+    <max-records>20</max-records>
+    <query>
+      <net-ipspaces-info>
+        <ipspace>c666</ipspace>
+      </net-ipspaces-info>
+    </query>
+  </net-ipspaces-get-iter>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceListSuccess_response.xml
+++ b/netapp/fixtures/TestNet_IPSpaceListSuccess_response.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100'
+  xmlns='http://www.netapp.com/filer/admin'>
+
+  <!-- Output of net-ipspaces-get-iter [Execution Time: 233 ms] -->
+  <results status='passed'>
+    <attributes-list>
+      <net-ipspaces-info>
+        <broadcast-domains>
+          <broadcast-domain-name>test-net-ipspace</broadcast-domain-name>
+        </broadcast-domains>
+        <id>25</id>
+        <ipspace>c666</ipspace>
+        <ports>
+          <net-qualified-port-name>lab-cluster01-02:a0a-3666</net-qualified-port-name>
+          <net-qualified-port-name>lab-cluster01-01:a0a-3666</net-qualified-port-name>
+        </ports>
+        <uuid>c61db834-9a57-11e8-bf6a-00a0983afb38</uuid>
+        <vservers>
+          <vserver-name>C666</vserver-name>
+          <vserver-name>c666</vserver-name>
+        </vservers>
+      </net-ipspaces-info>
+    </attributes-list>
+    <num-records>1</num-records>
+  </results>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceRenameFailure_request.xml
+++ b/netapp/fixtures/TestNet_IPSpaceRenameFailure_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-ipspaces-rename>
+    <ipspace>test-net-ipspace</ipspace>
+    <new-name>test-net-ipspace-new</new-name>
+  </net-ipspaces-rename>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceRenameFailure_response.xml
+++ b/netapp/fixtures/TestNet_IPSpaceRenameFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+	<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+		<!-- Output of net-ipspaces-rename [Execution Time: 161 ms] -->
+		<results reason='IPspace test-net-ipspace does not exist.' errno='13001' status='failed'/>
+	</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceRenameSuccess_request.xml
+++ b/netapp/fixtures/TestNet_IPSpaceRenameSuccess_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-ipspaces-rename>
+    <ipspace>test-net-ipspace</ipspace>
+    <new-name>test-net-ipspace-new</new-name>
+  </net-ipspaces-rename>
+</netapp>

--- a/netapp/fixtures/TestNet_IPSpaceRenameSuccess_response.xml
+++ b/netapp/fixtures/TestNet_IPSpaceRenameSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.110' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-ipspaces-rename [Execution Time: 318 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_NetInterfaceCreateSuccess_request.xml
+++ b/netapp/fixtures/TestNet_NetInterfaceCreateSuccess_request.xml
@@ -1,0 +1,15 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-interface-create>
+    <address>172.30.1.1</address>
+    <administrative-status>up</administrative-status>
+    <data-protocols>
+      <data-protocol>nfs</data-protocol>
+    </data-protocols>
+    <home-node>lab-cluster01-01</home-node>
+    <home-port>a0a-3666</home-port>
+    <interface-name>C666-v3666-1.1</interface-name>
+    <netmask>255.255.255.0</netmask>
+    <role>data</role>
+    <vserver>C666</vserver>
+  </net-interface-create>
+</netapp>

--- a/netapp/fixtures/TestNet_NetInterfaceCreateSuccess_response.xml
+++ b/netapp/fixtures/TestNet_NetInterfaceCreateSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-interface-create [Execution Time: 345 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_NetInterfaceDeleteSuccess_request.xml
+++ b/netapp/fixtures/TestNet_NetInterfaceDeleteSuccess_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-interface-delete>
+    <interface-name>C666-v3666-1.1</interface-name>
+    <vserver>C666</vserver>
+  </net-interface-delete>
+</netapp>

--- a/netapp/fixtures/TestNet_NetInterfaceDeleteSuccess_response.xml
+++ b/netapp/fixtures/TestNet_NetInterfaceDeleteSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-interface-delete [Execution Time: 233 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_NetRouteCreateSuccess_request.xml
+++ b/netapp/fixtures/TestNet_NetRouteCreateSuccess_request.xml
@@ -1,0 +1,8 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="C666">
+  <net-routes-create>
+    <destination>0.0.0.0/0</destination>
+    <gateway>172.30.1.199</gateway>
+    <metric>20</metric>
+    <return-record>true</return-record>
+  </net-routes-create>
+</netapp>

--- a/netapp/fixtures/TestNet_NetRouteCreateSuccess_response.xml
+++ b/netapp/fixtures/TestNet_NetRouteCreateSuccess_response.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-routes-create [Execution Time: 228 ms] -->
+	<results status='passed'>
+		<result>
+			<net-vs-routes-info>
+				<address-family>ipv4</address-family>
+				<destination>0.0.0.0/0</destination>
+				<gateway>172.30.1.199</gateway>
+				<metric>20</metric>
+				<vserver>C666</vserver>
+			</net-vs-routes-info>
+		</result>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestNet_NetRouteDeleteSuccess_request.xml
+++ b/netapp/fixtures/TestNet_NetRouteDeleteSuccess_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="C666">
+  <net-routes-destroy>
+    <destination>0.0.0.0/0</destination>
+    <gateway>172.30.1.199</gateway>
+  </net-routes-destroy>
+</netapp>

--- a/netapp/fixtures/TestNet_NetRouteDeleteSuccess_response.xml
+++ b/netapp/fixtures/TestNet_NetRouteDeleteSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-routes-destroy [Execution Time: 256 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanCreateFailure_request.xml
+++ b/netapp/fixtures/TestNet_VlanCreateFailure_request.xml
@@ -1,0 +1,9 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-vlan-create>
+    <vlan-info>
+      <node>test-cluster-01-01</node>
+      <parent-interface>a0a</parent-interface>
+      <vlanid>3555</vlanid>
+    </vlan-info>
+  </net-vlan-create>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanCreateFailure_response.xml
+++ b/netapp/fixtures/TestNet_VlanCreateFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-vlan-create [Execution Time: 163 ms] -->
+	<results reason='Invalid value specified for "node" element within "vlan-info": "test-cluster-01-01".' errno='13115' status='failed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanCreateSuccess_request.xml
+++ b/netapp/fixtures/TestNet_VlanCreateSuccess_request.xml
@@ -1,0 +1,9 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-vlan-create>
+    <vlan-info>
+      <node>test-cluster-01-01</node>
+      <parent-interface>a0a</parent-interface>
+      <vlanid>3555</vlanid>
+    </vlan-info>
+  </net-vlan-create>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanCreateSuccess_response.xml
+++ b/netapp/fixtures/TestNet_VlanCreateSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-vlan-create [Execution Time: 230 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanDeleteFailure_request.xml
+++ b/netapp/fixtures/TestNet_VlanDeleteFailure_request.xml
@@ -1,0 +1,9 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-vlan-delete>
+    <vlan-info>
+      <node>test-cluster-01-01</node>
+      <parent-interface>a0a</parent-interface>
+      <vlanid>3455</vlanid>
+    </vlan-info>
+  </net-vlan-delete>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanDeleteFailure_response.xml
+++ b/netapp/fixtures/TestNet_VlanDeleteFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-vlan-create [Execution Time: 163 ms] -->
+	<results reason='Invalid value specified for "node" element within "vlan-info": "test-cluster-01-01".' errno='13115' status='failed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanDeleteSuccess_request.xml
+++ b/netapp/fixtures/TestNet_VlanDeleteSuccess_request.xml
@@ -1,0 +1,9 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-vlan-delete>
+    <vlan-info>
+      <node>test-cluster-01-01</node>
+      <parent-interface>a0a</parent-interface>
+      <vlanid>3555</vlanid>
+    </vlan-info>
+  </net-vlan-delete>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanDeleteSuccess_response.xml
+++ b/netapp/fixtures/TestNet_VlanDeleteSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-vlan-create [Execution Time: 230 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanGetFailure_request.xml
+++ b/netapp/fixtures/TestNet_VlanGetFailure_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-vlan-get>
+    <interface-name>a0a-3555</interface-name>
+    <node>test-cluster-01-01</node>
+  </net-vlan-get>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanGetFailure_response.xml
+++ b/netapp/fixtures/TestNet_VlanGetFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-vlan-get [Execution Time: 150 ms] -->
+	<results reason='Invalid value specified for "node" element within "net-vlan-get": "test-cluster-01-01".' errno='13115' status='failed'/>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanGetSuccess_request.xml
+++ b/netapp/fixtures/TestNet_VlanGetSuccess_request.xml
@@ -1,0 +1,6 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-vlan-get>
+    <interface-name>a0a-3555</interface-name>
+    <node>test-cluster-01-01</node>
+  </net-vlan-get>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanGetSuccess_response.xml
+++ b/netapp/fixtures/TestNet_VlanGetSuccess_response.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of net-vlan-get [Execution Time: 174 ms] -->
+	<results status='passed'>
+		<attributes>
+			<vlan-info>
+				<interface-name>a0a-3555</interface-name>
+				<node>test-cluster-01-01</node>
+				<parent-interface>a0a</parent-interface>
+				<vlanid>3555</vlanid>
+			</vlan-info>
+		</attributes>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanListSuccess_request.xml
+++ b/netapp/fixtures/TestNet_VlanListSuccess_request.xml
@@ -1,0 +1,11 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <net-vlan-get-iter>
+    <max-records>20</max-records>
+    <query>
+      <vlan-info>
+        <parent-interface>a0a</parent-interface>
+        <vlanid>3555</vlanid>
+      </vlan-info>
+    </query>
+  </net-vlan-get-iter>
+</netapp>

--- a/netapp/fixtures/TestNet_VlanListSuccess_response.xml
+++ b/netapp/fixtures/TestNet_VlanListSuccess_response.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100'
+  xmlns='http://www.netapp.com/filer/admin'>
+
+  <!-- Output of net-vlan-get-iter [Execution Time: 299 ms] -->
+  <results status='passed'>
+    <attributes-list>
+      <vlan-info>
+        <interface-name>a0a-3555</interface-name>
+        <node>test-cluster-01-01</node>
+        <parent-interface>a0a</parent-interface>
+        <vlanid>3555</vlanid>
+      </vlan-info>
+      <vlan-info>
+        <interface-name>a0a-3555</interface-name>
+        <node>test-cluster-01-02</node>
+        <parent-interface>a0a</parent-interface>
+        <vlanid>3555</vlanid>
+      </vlan-info>
+    </attributes-list>
+    <num-records>2</num-records>
+  </results>
+</netapp>

--- a/netapp/net-broadcast-domain.go
+++ b/netapp/net-broadcast-domain.go
@@ -1,0 +1,106 @@
+package netapp
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+type netBroadcastDomainRequest struct {
+	Base
+	Params struct {
+		XMLName xml.Name
+		NetBroadcastDomainOptions
+		NetBroadcastDomainCreateOptions `xml:",innerxml"`
+	}
+}
+
+// NetBroadcastDomainOptions get/list options for getting broadcast domains
+type NetBroadcastDomainOptions struct {
+	DesiredAttributes *NetBroadcastDomainInfo `xml:"desired-attributes,omitempty"`
+	MaxRecords        int                     `xml:"max-records,omitempty"`
+	Query             *NetBroadcastDomainInfo `xml:"query,omitempty"`
+	Tag               string                  `xml:"tag,omitempty"`
+}
+
+// NetBroadcastDomainInfo is the Broadcast Domain data
+type NetBroadcastDomainInfo struct {
+	BroadcastDomain          string               `xml:"broadcast-domain,omitempty"`
+	FailoverGroups           []string             `xml:"failover-groups>failover-group"`
+	IPSpace                  string               `xml:"ipspace,omitempty"`
+	MTU                      int                  `xml:"mtu,omitempty"`
+	CombinedPortUpdateStatus string               `xml:"port-update-status-combined,omitempty"`
+	Ports                    *[]NetPortUpdateInfo `xml:"ports>port-info"`
+	SubnetNames              []string             `xml:"subnet-names>subnet-name"`
+}
+
+// NetBroadcastDomainCreateOptions used for creating new Broadcast Domain
+type NetBroadcastDomainCreateOptions struct {
+	BroadcastDomain string    `xml:"broadcast-domain"`
+	IPSpace         string    `xml:"ipspace"`
+	MTU             int       `xml:"mtu,omitempty"`
+	Ports           *[]string `xml:"ports>net-qualified-port-name,omitempty"`
+}
+
+// NetPortUpdateInfo is port info for the broadcast domain
+type NetPortUpdateInfo struct {
+	Port                    string `xml:"port"`
+	PortUpdateStatus        string `xml:"port-update-status"`
+	PortUpdateStatusDetails string `xml:"port-update-status-details"`
+}
+
+// NetBroadcastDomainResponse returns results for broadcast domains
+type NetBroadcastDomainResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+		Info NetBroadcastDomainInfo `xml:"attributes>net-port-broadcast-domain-info"`
+	} `xml:"results"`
+}
+
+// NetBroadcastDomainCreateResponse returns result of creating a new broadcast domain
+type NetBroadcastDomainCreateResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+		CombinedPortUpdateStatus string `xml:"port-update-status-combined"`
+	} `xml:"results"`
+}
+
+// CreateBroadcastDomain creates a new broadcast domain
+func (n Net) CreateBroadcastDomain(createOptions *NetBroadcastDomainCreateOptions) (*NetBroadcastDomainCreateResponse, *http.Response, error) {
+	req := n.newNetBroadcastDomainRequest()
+	req.Params.XMLName = xml.Name{Local: "net-port-broadcast-domain-create"}
+	req.Params.NetBroadcastDomainCreateOptions = *createOptions
+
+	r := NetBroadcastDomainCreateResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}
+
+// GetBroadcastDomain grabs a single named broadcast domain
+func (n Net) GetBroadcastDomain(domain string, ipSpace string) (*NetBroadcastDomainResponse, *http.Response, error) {
+	req := n.newNetBroadcastDomainRequest()
+	req.Params.XMLName = xml.Name{Local: "net-port-broadcast-domain-get"}
+	req.Params.BroadcastDomain = domain
+	req.Params.IPSpace = ipSpace
+	r := NetBroadcastDomainResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}
+
+func (n Net) DeleteBroadcastDomain(domain string, ipSpace string) (*NetBroadcastDomainCreateResponse, *http.Response, error) {
+	req := n.newNetBroadcastDomainRequest()
+	req.Params.XMLName = xml.Name{Local: "net-port-broadcast-domain-destroy"}
+	req.Params.BroadcastDomain = domain
+	req.Params.IPSpace = ipSpace
+
+	r := NetBroadcastDomainCreateResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}
+
+func (n Net) newNetBroadcastDomainRequest() *netBroadcastDomainRequest {
+	return &netBroadcastDomainRequest{
+		Base: n.Base,
+	}
+}

--- a/netapp/net-broadcast-domain_test.go
+++ b/netapp/net-broadcast-domain_test.go
@@ -1,0 +1,112 @@
+package netapp_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pepabo/go-netapp/netapp"
+)
+
+func TestNet_BroadcastDomainGetSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.GetBroadcastDomain("test-bdomain", "test-net-ipspace")
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+
+	info := call.Results.Info
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"Broadcast Domains", info.BroadcastDomain, "test-bdomain"},
+		{"Failover Groups", info.FailoverGroups, []string{"test-bdomain"}},
+		{"IPSpace", info.IPSpace, "test-net-ipspace"},
+		{"MTU", info.MTU, 1500},
+		{"Port", (*info.Ports)[0], netapp.NetPortUpdateInfo{
+			Port:                    "lab-cluster01-02:a0a-3555",
+			PortUpdateStatus:        "complete",
+			PortUpdateStatusDetails: "complete",
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Errorf("Net.GetBroadcastDomain() got = %+v, want %+v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNet_BroadcastDomainGetFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.GetBroadcastDomain("other-bdomain", "test-ip-space")
+
+	results := &call.Results.SingleResultBase
+	checkResponseFailure(results, err, t)
+
+	testFailureResult(15661, `entry doesn"t exist`, results, t)
+}
+
+func TestNet_BroadcastDomainCreateSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.CreateBroadcastDomain(&netapp.NetBroadcastDomainCreateOptions{
+		BroadcastDomain: "test-bcastdomain",
+		IPSpace:         "test-ip-space",
+		MTU:             1500,
+		Ports:           &[]string{"lab-cluster01-01:a0a-3555", "lab-cluster01-02:a0a-3555"},
+	})
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+
+	expected := "complete"
+	if call.Results.CombinedPortUpdateStatus != expected {
+		t.Errorf("Response was %s, expected %s", call.Results.CombinedPortUpdateStatus, expected)
+	}
+}
+
+func TestNet_BroadcastDomainCreateFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.CreateBroadcastDomain(&netapp.NetBroadcastDomainCreateOptions{
+		BroadcastDomain: "test-bcastdomain",
+		IPSpace:         "test-ip-space",
+		MTU:             1500,
+	})
+
+	results := &call.Results.SingleResultBase
+	checkResponseFailure(results, err, t)
+
+	testFailureResult(18603, "Specified IPspace not found", results, t)
+}
+
+func TestNet_BroadcastDomainDeleteSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.DeleteBroadcastDomain("test-bcastdomain", "test-ip-space")
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+
+	expected := "complete"
+	if call.Results.CombinedPortUpdateStatus != expected {
+		t.Errorf("Response was %s, expected %s", call.Results.CombinedPortUpdateStatus, expected)
+	}
+}
+
+func TestNet_BroadcastDomainDeleteFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.DeleteBroadcastDomain("test-bcastdomain", "test-ip-space")
+
+	results := &call.Results.SingleResultBase
+	checkResponseFailure(results, err, t)
+
+	testFailureResult(18604, `Broadcast domain "test-bcastdomain" in IPspace "test-ip-space" not found.`, results, t)
+}

--- a/netapp/net-ipspace.go
+++ b/netapp/net-ipspace.go
@@ -1,0 +1,101 @@
+package netapp
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+type netIPSpaceRequest struct {
+	Base
+	CreateParams *netIPSpaceCreateParams `xml:"net-ipspaces-create,omitempty"`
+	GetParams    *netIPSpaceGetParams    `xml:"net-ipspaces-get,omitempty"`
+	RenameParams *netIPSpaceRenameParams `xml:"net-ipspaces-rename,omitempty"`
+	DeleteParams *netIPSpaceGetParams    `xml:"net-ipspaces-destroy,omitempty"`
+}
+
+type netIPSpaceCreateParams struct {
+	IPSpace      string `xml:"ipspace"`
+	ReturnRecord bool   `xml:"return-record"`
+}
+
+type netIPSpaceGetParams struct {
+	IPSpace string `xml:"ipspace"`
+}
+
+type netIPSpaceRenameParams struct {
+	IPSpace string `xml:"ipspace"`
+	NewName string `xml:"new-name"`
+}
+
+// NetIPSpaceInfo holds newly created ipspace variables
+type NetIPSpaceInfo struct {
+	BroadcastDomains []string `xml:"broadcast-domains>broadcast-domain-name,omitempty"`
+	ID               int      `xml:"id"`
+	IPSpace          string   `xml:"ipspace"`
+	Ports            []string `xml:"ports>net-qualified-port-name,omitempty"`
+	UUID             string   `xml:"uuid"`
+	VServers         []string `xml:"vservers>vserver-name"`
+}
+
+// NetIPSpaceResponse is return type for net ip space requests
+type NetIPSpaceResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+		NetIPSpaceInfo       `xml:",innerxml"`
+		NetIPSpaceCreateInfo *NetIPSpaceInfo `xml:"result>net-ipspaces-info"`
+	} `xml:"results"`
+}
+
+// CreateIPSpace creates a new ipspace on the cluster
+func (n Net) CreateIPSpace(name string, returnRecord bool) (*NetIPSpaceResponse, *http.Response, error) {
+	req := n.newNetIPSpaceRequest()
+	req.CreateParams = &netIPSpaceCreateParams{
+		IPSpace:      name,
+		ReturnRecord: returnRecord,
+	}
+	return n.newNetIPSpaceResponse(req)
+}
+
+// GetIPSpace grabs data for an ip space
+func (n Net) GetIPSpace(name string) (*NetIPSpaceResponse, *http.Response, error) {
+	req := n.newNetIPSpaceRequest()
+	req.GetParams = &netIPSpaceGetParams{
+		IPSpace: name,
+	}
+
+	return n.newNetIPSpaceResponse(req)
+}
+
+// RenameIPSpace changes the name of an ipspace
+func (n Net) RenameIPSpace(name string, newName string) (*NetIPSpaceResponse, *http.Response, error) {
+	req := n.newNetIPSpaceRequest()
+	req.RenameParams = &netIPSpaceRenameParams{
+		IPSpace: name,
+		NewName: newName,
+	}
+
+	return n.newNetIPSpaceResponse(req)
+}
+
+// DeleteIPSpace deletes an IPSpace
+func (n Net) DeleteIPSpace(name string) (*NetIPSpaceResponse, *http.Response, error) {
+	req := n.newNetIPSpaceRequest()
+	req.DeleteParams = &netIPSpaceGetParams{
+		IPSpace: name,
+	}
+
+	return n.newNetIPSpaceResponse(req)
+}
+
+func (n Net) newNetIPSpaceRequest() *netIPSpaceRequest {
+	return &netIPSpaceRequest{
+		Base: n.Base,
+	}
+}
+
+func (n Net) newNetIPSpaceResponse(req *netIPSpaceRequest) (*NetIPSpaceResponse, *http.Response, error) {
+	r := NetIPSpaceResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}

--- a/netapp/net-ipspace_test.go
+++ b/netapp/net-ipspace_test.go
@@ -15,7 +15,7 @@ func TestNet_IPSpaceCreateSuccess(t *testing.T) {
 	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
 
 	info := call.Results.NetIPSpaceCreateInfo
-	var nilSlice []string
+	var nilSlice *[]string
 	tests := []struct {
 		name string
 		got  interface{}
@@ -26,7 +26,7 @@ func TestNet_IPSpaceCreateSuccess(t *testing.T) {
 		{"IP Space", info.IPSpace, "test-ip-space"},
 		{"Ports", info.Ports, nilSlice},
 		{"UUID", info.UUID, "af9fa457-c02d-11e8-bf6a-00a0983afb38"},
-		{"VServers", info.VServers, []string{"test-ip-space"}},
+		{"VServers", info.VServers, &[]string{"test-ip-space"}},
 	}
 
 	for _, tt := range tests {
@@ -64,9 +64,9 @@ func TestNet_IPSpaceGetSuccess(t *testing.T) {
 		got  interface{}
 		want interface{}
 	}{
-		{"Broadcast Domains", info.BroadcastDomains, []string{"test-net-ipspace"}},
-		{"Ports", info.Ports, []string{"lab-cluster01-02:a0a-3555", "lab-cluster01-01:a0a-3555"}},
-		{"VServers", info.VServers, []string{"Test-Vserver", "test-vserver"}},
+		{"Broadcast Domains", info.BroadcastDomains, &[]string{"test-net-ipspace"}},
+		{"Ports", info.Ports, &[]string{"lab-cluster01-02:a0a-3555", "lab-cluster01-01:a0a-3555"}},
+		{"VServers", info.VServers, &[]string{"Test-Vserver", "test-vserver"}},
 		{"Create Info is empty", call.Results.NetIPSpaceCreateInfo, createInfo},
 	}
 
@@ -74,6 +74,38 @@ func TestNet_IPSpaceGetSuccess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if !reflect.DeepEqual(tt.got, tt.want) {
 				t.Errorf("Net.GetIPSpace() got = %+v, want %+v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNet_IPSpaceListSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	query := &netapp.NetIPSpaceInfo{
+		IPSpace: "c666",
+	}
+	call, _, err := c.Net.ListIPSpaces(query)
+	checkResponseSuccess(&call.Results.ResultBase, err, t)
+
+	info := call.Results.Info[0]
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"UUID", info.UUID, "c61db834-9a57-11e8-bf6a-00a0983afb38"},
+		{"ID", info.ID, 25},
+		{"Broadcast Domains", info.BroadcastDomains, &[]string{"test-net-ipspace"}},
+		{"Ports", info.Ports, &[]string{"lab-cluster01-02:a0a-3666", "lab-cluster01-01:a0a-3666"}},
+		{"VServers", info.VServers, &[]string{"C666", "c666"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Errorf("Net.ListIPSpaces() got = %+v, want %+v", tt.got, tt.want)
 			}
 		})
 	}

--- a/netapp/net-ipspace_test.go
+++ b/netapp/net-ipspace_test.go
@@ -1,0 +1,130 @@
+package netapp_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pepabo/go-netapp/netapp"
+)
+
+func TestNet_IPSpaceCreateSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.CreateIPSpace("test-ip-space", true)
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+
+	info := call.Results.NetIPSpaceCreateInfo
+	var nilSlice []string
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"Broadcast Domains", info.BroadcastDomains, nilSlice},
+		{"ID", info.ID, 39},
+		{"IP Space", info.IPSpace, "test-ip-space"},
+		{"Ports", info.Ports, nilSlice},
+		{"UUID", info.UUID, "af9fa457-c02d-11e8-bf6a-00a0983afb38"},
+		{"VServers", info.VServers, []string{"test-ip-space"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Errorf("Net.CreateIPSpace() got = %+v, want %+v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNet_IPSpaceCreateFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.CreateIPSpace("test-ip-space", false)
+
+	results := &call.Results.SingleResultBase
+	checkResponseFailure(results, err, t)
+
+	testFailureResult(13001, `Invalid IPspace name. The name "test-ip-space" is already in use by a cluster node, Vserver, or is the name of the local cluster.`, results, t)
+}
+
+func TestNet_IPSpaceGetSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.GetIPSpace("test-net-ipspace")
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+
+	var createInfo *netapp.NetIPSpaceInfo
+	info := call.Results.NetIPSpaceInfo
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"Broadcast Domains", info.BroadcastDomains, []string{"test-net-ipspace"}},
+		{"Ports", info.Ports, []string{"lab-cluster01-02:a0a-3555", "lab-cluster01-01:a0a-3555"}},
+		{"VServers", info.VServers, []string{"Test-Vserver", "test-vserver"}},
+		{"Create Info is empty", call.Results.NetIPSpaceCreateInfo, createInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Errorf("Net.GetIPSpace() got = %+v, want %+v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNet_IPSpaceGetFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.GetIPSpace("test-ip-space")
+
+	results := &call.Results.SingleResultBase
+	checkResponseFailure(results, err, t)
+
+	testFailureResult(15661, `entry doesn"t exist`, results, t)
+
+}
+
+func TestNet_IPSpaceRenameSuccess(t *testing.T) {
+
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.RenameIPSpace("test-net-ipspace", "test-net-ipspace-new")
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}
+
+func TestNet_IPSpaceRenameFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.RenameIPSpace("test-net-ipspace", "test-net-ipspace-new")
+	checkResponseFailure(&call.Results.SingleResultBase, err, t)
+
+	testFailureResult(13001, "IPspace test-net-ipspace does not exist.", &call.Results.SingleResultBase, t)
+}
+
+func TestNet_IPSpaceDeleteSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.DeleteIPSpace("test-net-ipspace-new")
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}
+
+func TestNet_IPSpaceDeleteFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.DeleteIPSpace("test-net-ipspace-new")
+	checkResponseFailure(&call.Results.SingleResultBase, err, t)
+
+	testFailureResult(15661, `entry doesn"t exist`, &call.Results.SingleResultBase, t)
+}

--- a/netapp/net-vlan.go
+++ b/netapp/net-vlan.go
@@ -1,0 +1,81 @@
+package netapp
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+type netVlanRequest struct {
+	Base
+	Params struct {
+		XMLName     xml.Name
+		NetVlanInfo `xml:",innerxml"`
+		VlanInfo    *NetVlanInfo `xml:"vlan-info,omitempty"`
+	}
+}
+
+// NetVlanOptions get/list options for getting broadcast domains
+type NetVlanOptions struct {
+	DesiredAttributes *NetVlanInfo `xml:"desired-attributes,omitempty"`
+	MaxRecords        int          `xml:"max-records,omitempty"`
+	Query             *NetVlanInfo `xml:"query,omitempty"`
+	Tag               string       `xml:"tag,omitempty"`
+}
+
+// NetVlanInfo is the Broadcast Domain data
+type NetVlanInfo struct {
+	InterfaceName   string `xml:"interface-name,omitempty"`
+	Node            string `xml:"node,omitempty"`
+	ParentInterface string `xml:"parent-interface,omitempty"`
+	VlanID          int    `xml:"vlanid,omitempty"`
+}
+
+// NetVlanResponse returns results for broadcast domains
+type NetVlanResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+		Info NetVlanInfo `xml:"attributes>vlan-info"`
+	} `xml:"results"`
+}
+
+// CreateVlan creates a new broadcast domain
+func (n Net) CreateVlan(options *NetVlanInfo) (*SingleResultResponse, *http.Response, error) {
+	req := n.newNetVlanRequest()
+	req.Params.XMLName = xml.Name{Local: "net-vlan-create"}
+
+	options.InterfaceName = ""
+	req.Params.VlanInfo = options
+
+	r := SingleResultResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}
+
+// GetVlan grabs a single named broadcast domain
+func (n Net) GetVlan(interfaceName string, node string) (*NetVlanResponse, *http.Response, error) {
+	req := n.newNetVlanRequest()
+	req.Params.XMLName = xml.Name{Local: "net-vlan-get"}
+	req.Params.InterfaceName = interfaceName
+	req.Params.Node = node
+	r := NetVlanResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}
+
+// DeleteVlan removes vlan from existence
+func (n Net) DeleteVlan(options *NetVlanInfo) (*SingleResultResponse, *http.Response, error) {
+	req := n.newNetVlanRequest()
+	req.Params.XMLName = xml.Name{Local: "net-vlan-delete"}
+	options.InterfaceName = ""
+	req.Params.VlanInfo = options
+	r := SingleResultResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}
+
+func (n Net) newNetVlanRequest() *netVlanRequest {
+	return &netVlanRequest{
+		Base: n.Base,
+	}
+}

--- a/netapp/net-vlan.go
+++ b/netapp/net-vlan.go
@@ -2,27 +2,30 @@ package netapp
 
 import (
 	"encoding/xml"
+	"fmt"
 	"net/http"
 )
 
 type netVlanRequest struct {
 	Base
 	Params struct {
-		XMLName     xml.Name
-		NetVlanInfo `xml:",innerxml"`
-		VlanInfo    *NetVlanInfo `xml:"vlan-info,omitempty"`
+		XMLName         xml.Name
+		NetVlanInfo     `xml:",innerxml"`
+		*NetVlanOptions `xml:",innerxml"`
+
+		VlanInfo *NetVlanInfo `xml:"vlan-info,omitempty"`
 	}
 }
 
-// NetVlanOptions get/list options for getting broadcast domains
+// NetVlanOptions get/list options for getting vlans
 type NetVlanOptions struct {
-	DesiredAttributes *NetVlanInfo `xml:"desired-attributes,omitempty"`
+	DesiredAttributes *NetVlanInfo `xml:"desired-attributes>vlan-info,omitempty"`
 	MaxRecords        int          `xml:"max-records,omitempty"`
-	Query             *NetVlanInfo `xml:"query,omitempty"`
+	Query             *NetVlanInfo `xml:"query>vlan-info,omitempty"`
 	Tag               string       `xml:"tag,omitempty"`
 }
 
-// NetVlanInfo is the Broadcast Domain data
+// NetVlanInfo is the Vlan data
 type NetVlanInfo struct {
 	InterfaceName   string `xml:"interface-name,omitempty"`
 	Node            string `xml:"node,omitempty"`
@@ -30,7 +33,7 @@ type NetVlanInfo struct {
 	VlanID          int    `xml:"vlanid,omitempty"`
 }
 
-// NetVlanResponse returns results for broadcast domains
+// NetVlanResponse returns results for a single vlan
 type NetVlanResponse struct {
 	XMLName xml.Name `xml:"netapp"`
 	Results struct {
@@ -39,7 +42,21 @@ type NetVlanResponse struct {
 	} `xml:"results"`
 }
 
-// CreateVlan creates a new broadcast domain
+// NetVlanListResponse returns results for a list of vlans
+type NetVlanListResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		ResultBase
+		Info []NetVlanInfo `xml:"attributes-list>vlan-info"`
+	} `xml:"results"`
+}
+
+// ToString converts to string, ie test-cluster-01-01:a0a-3555
+func (v *NetVlanInfo) ToString() string {
+	return fmt.Sprintf("%s:%s-%d", v.Node, v.ParentInterface, v.VlanID)
+}
+
+// CreateVlan creates a new vlan
 func (n Net) CreateVlan(options *NetVlanInfo) (*SingleResultResponse, *http.Response, error) {
 	req := n.newNetVlanRequest()
 	req.Params.XMLName = xml.Name{Local: "net-vlan-create"}
@@ -59,6 +76,21 @@ func (n Net) GetVlan(interfaceName string, node string) (*NetVlanResponse, *http
 	req.Params.InterfaceName = interfaceName
 	req.Params.Node = node
 	r := NetVlanResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}
+
+// ListVlans lists all vlans that match info query
+func (n Net) ListVlans(info *NetVlanInfo) (*NetVlanListResponse, *http.Response, error) {
+	req := n.newNetVlanRequest()
+
+	req.Params.XMLName = xml.Name{Local: "net-vlan-get-iter"}
+	req.Params.NetVlanOptions = &NetVlanOptions{
+		Query:      info,
+		MaxRecords: 20,
+	}
+
+	r := NetVlanListResponse{}
 	res, err := n.get(req, &r)
 	return &r, res, err
 }

--- a/netapp/net-vlan_test.go
+++ b/netapp/net-vlan_test.go
@@ -1,0 +1,105 @@
+package netapp_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pepabo/go-netapp/netapp"
+)
+
+func TestNet_VlanGetSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.GetVlan("a0a-3555", "test-cluster-01-01")
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+
+	info := call.Results.Info
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"Interface Name", info.InterfaceName, "a0a-3555"},
+		{"Node", info.Node, "test-cluster-01-01"},
+		{"Parent Interface", info.ParentInterface, "a0a"},
+		{"VLanID", info.VlanID, 3555},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Errorf("Net.GetVlan() got = %+v, want %+v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNet_VlanGetFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.GetVlan("a0a-3555", "test-cluster-01-01")
+
+	results := &call.Results.SingleResultBase
+	checkResponseFailure(results, err, t)
+
+	testFailureResult(13115, `Invalid value specified for "node" element within "net-vlan-get": "test-cluster-01-01".`, results, t)
+}
+
+func TestNet_VlanCreateSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.CreateVlan(&netapp.NetVlanInfo{
+		InterfaceName:   "I shouldn't be sent to the server",
+		ParentInterface: "a0a",
+		Node:            "test-cluster-01-01",
+		VlanID:          3555,
+	})
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}
+
+func TestNet_VlanCreateFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.CreateVlan(&netapp.NetVlanInfo{
+		ParentInterface: "a0a",
+		Node:            "test-cluster-01-01",
+		VlanID:          3555,
+	})
+
+	results := &call.Results.SingleResultBase
+	checkResponseFailure(results, err, t)
+
+	testFailureResult(13115, `Invalid value specified for "node" element within "vlan-info": "test-cluster-01-01".`, results, t)
+}
+
+func TestNet_VlanDeleteSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.DeleteVlan(&netapp.NetVlanInfo{
+		ParentInterface: "a0a",
+		Node:            "test-cluster-01-01",
+		VlanID:          3555,
+	})
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}
+
+func TestNet_VlanDeleteFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.DeleteVlan(&netapp.NetVlanInfo{
+		ParentInterface: "a0a",
+		Node:            "test-cluster-01-01",
+		VlanID:          3455,
+	})
+
+	results := &call.Results.SingleResultBase
+	checkResponseFailure(results, err, t)
+
+	testFailureResult(13115, `Invalid value specified for "node" element within "vlan-info": "test-cluster-01-01".`, results, t)
+}

--- a/netapp/net-vlan_test.go
+++ b/netapp/net-vlan_test.go
@@ -47,6 +47,38 @@ func TestNet_VlanGetFailure(t *testing.T) {
 	testFailureResult(13115, `Invalid value specified for "node" element within "net-vlan-get": "test-cluster-01-01".`, results, t)
 }
 
+func TestNet_VlanListSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	options := &netapp.NetVlanInfo{
+		ParentInterface: "a0a",
+		VlanID:          3555,
+	}
+	call, _, err := c.Net.ListVlans(options)
+	checkResponseSuccess(&call.Results.ResultBase, err, t)
+
+	info := call.Results.Info[0]
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"Interface Name", info.InterfaceName, "a0a-3555"},
+		{"Node", info.Node, "test-cluster-01-01"},
+		{"Parent Interface", info.ParentInterface, "a0a"},
+		{"VLanID", info.VlanID, 3555},
+		{"Port String", info.ToString(), "test-cluster-01-01:a0a-3555"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Errorf("Net.GetVlan() got = %+v, want %+v", tt.got, tt.want)
+			}
+		})
+	}
+}
 func TestNet_VlanCreateSuccess(t *testing.T) {
 	c, teardown := createTestClientWithFixtures(t)
 	defer teardown()

--- a/netapp/net.go
+++ b/netapp/net.go
@@ -127,28 +127,29 @@ type NetInterfaceOptions struct {
 }
 
 type NetInterfaceInfo struct {
-	Address              string `xml:"address"`
-	AdministrativeStatus string `xml:"administrative-status"`
-	Comment              string `xml:"comment"`
-	CurrentNode          string `xml:"current-node"`
-	CurrentPort          string `xml:"current-port"`
-	DnsDomainName        string `xml:"dns-domain-name"`
-	FailoverGroup        string `xml:"failover-group"`
-	FailoverPolicy       string `xml:"failover-policy"`
-	FirewallPolicy       string `xml:"firewall-policy"`
-	HomeNode             string `xml:"home-node"`
-	HomePort             string `xml:"home-port"`
-	InterfaceName        string `xml:"interface-name"`
-	IsAutoRevert         bool   `xml:"is-auto-revert"`
-	IsHome               bool   `xml:"is-home"`
-	IsIpv4LinkLocal      bool   `xml:"is-ipv4-link-local"`
-	Netmask              string `xml:"netmask"`
-	NetmaskLength        int    `xml:"netmask-length"`
-	OperationalStatus    string `xml:"operational-status"`
-	Role                 string `xml:"role"`
-	RoutingGroupName     string `xml:"routing-group-name"`
-	UseFailoverGroup     string `xml:"use-failover-group"`
-	Vserver              string `xml:"vserver"`
+	Address              string    `xml:"address,omitempty"`
+	AdministrativeStatus string    `xml:"administrative-status,omitempty"`
+	Comment              string    `xml:"comment,omitempty"`
+	DataProtocols        *[]string `xml:"data-protocols>data-protocol"`
+	CurrentNode          string    `xml:"current-node,omitempty"`
+	CurrentPort          string    `xml:"current-port,omitempty"`
+	DnsDomainName        string    `xml:"dns-domain-name,omitempty"`
+	FailoverGroup        string    `xml:"failover-group,omitempty"`
+	FailoverPolicy       string    `xml:"failover-policy,omitempty"`
+	FirewallPolicy       string    `xml:"firewall-policy,omitempty"`
+	HomeNode             string    `xml:"home-node,omitempty"`
+	HomePort             string    `xml:"home-port,omitempty"`
+	InterfaceName        string    `xml:"interface-name"`
+	IsAutoRevert         bool      `xml:"is-auto-revert,omitempty"`
+	IsHome               bool      `xml:"is-home,omitempty"`
+	IsIpv4LinkLocal      bool      `xml:"is-ipv4-link-local,omitempty"`
+	Netmask              string    `xml:"netmask,omitempty"`
+	NetmaskLength        int       `xml:"netmask-length,omitempty"`
+	OperationalStatus    string    `xml:"operational-status,omitempty"`
+	Role                 string    `xml:"role,omitempty"`
+	RoutingGroupName     string    `xml:"routing-group-name,omitempty"`
+	UseFailoverGroup     string    `xml:"use-failover-group,omitempty"`
+	Vserver              string    `xml:"vserver"`
 }
 
 type NetInterfaceGetIterResponse struct {
@@ -170,6 +171,31 @@ type NetInterfacePageResponse struct {
 }
 
 type NetInterfacePageHandler func(NetInterfacePageResponse) (shouldContinue bool)
+
+// CreateNetInterface creates a new network interface
+func (n Net) CreateNetInterface(options *NetInterfaceInfo) (*SingleResultResponse, *http.Response, error) {
+	req := netInterfaceCreateRequest{
+		Base: n.Base,
+	}
+	req.Params.XMLName = xml.Name{Local: "net-interface-create"}
+	req.Params.NetInterfaceInfo = *options
+	r := SingleResultResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}
+
+// DeleteNetInterface removes a LIF from a vserver
+func (n Net) DeleteNetInterface(vServerName string, lif string) (*SingleResultResponse, *http.Response, error) {
+	req := netInterfaceCreateRequest{
+		Base: n.Base,
+	}
+	req.Params.XMLName = xml.Name{Local: "net-interface-delete"}
+	req.Params.Vserver = vServerName
+	req.Params.InterfaceName = lif
+	r := SingleResultResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}
 
 func (n *Net) NetInterfaceGetIter(options *NetInterfaceOptions) (*NetInterfaceGetIterResponse, *http.Response, error) {
 	params := newNetInterfaceGetIterParams(options, n.Base)
@@ -201,6 +227,14 @@ func (n *Net) NetInterfaceGetAll(options *NetInterfaceOptions, fn NetInterfacePa
 
 }
 
+type netInterfaceCreateRequest struct {
+	Base
+	Params struct {
+		XMLName          xml.Name
+		NetInterfaceInfo `xml:",innerxml"`
+	}
+}
+
 type netInterfaceGetIterParams struct {
 	Base
 	Params struct {
@@ -216,4 +250,57 @@ func newNetInterfaceGetIterParams(options *NetInterfaceOptions, base Base) *netI
 	params.Params.XMLName = xml.Name{Local: "net-interface-get-iter"}
 	params.Params.NetInterfaceOptions = options
 	return &params
+}
+
+// NetRoutingGroupRouteInfo holds route information
+type NetRoutesInfo struct {
+	AddressFamily      string `xml:"address-family,omitempty"`
+	DestinationAddress string `xml:"destination"`
+	GatewayAddress     string `xml:"gateway"`
+	Metric             int    `xml:"metric,omitempty"`
+	ReturnRecord       bool   `xml:"return-record,omitempty"`
+	VServer            string `xml:"vserver,omitempty"`
+}
+
+type netRoutesRequest struct {
+	Base
+	Params struct {
+		XMLName       xml.Name
+		NetRoutesInfo `xml:",innerxml"`
+	}
+}
+
+type NetRoutesResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+		Info NetRoutesInfo `xml:"result>net-vs-routes-info"`
+	} `xml:"results"`
+}
+
+// CreateRoute creates a new route for Routing Group
+func (n Net) CreateRoute(vServerName string, options *NetRoutesInfo) (*NetRoutesResponse, *http.Response, error) {
+	req := netRoutesRequest{
+		Base: n.Base,
+	}
+	req.Name = vServerName
+	req.Params.XMLName = xml.Name{Local: "net-routes-create"}
+	req.Params.NetRoutesInfo = *options
+	r := NetRoutesResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
+}
+
+// DeleteRoute creates a new route for Routing Group
+func (n Net) DeleteRoute(vServerName string, destination string, gateway string) (*SingleResultResponse, *http.Response, error) {
+	req := netRoutesRequest{
+		Base: n.Base,
+	}
+	req.Name = vServerName
+	req.Params.XMLName = xml.Name{Local: "net-routes-destroy"}
+	req.Params.DestinationAddress = destination
+	req.Params.GatewayAddress = gateway
+	r := SingleResultResponse{}
+	res, err := n.get(req, &r)
+	return &r, res, err
 }

--- a/netapp/net_test.go
+++ b/netapp/net_test.go
@@ -1,0 +1,85 @@
+package netapp_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pepabo/go-netapp/netapp"
+)
+
+func TestNet_NetInterfaceCreateSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	opts := &netapp.NetInterfaceInfo{
+		Vserver:              "C666",
+		InterfaceName:        "C666-v3666-1.1",
+		Role:                 "data",
+		Address:              "172.30.1.1",
+		DataProtocols:        &[]string{"nfs"},
+		HomeNode:             "lab-cluster01-01",
+		HomePort:             "a0a-3666",
+		Netmask:              "255.255.255.0",
+		AdministrativeStatus: "up",
+	}
+
+	call, _, err := c.Net.CreateNetInterface(opts)
+
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}
+
+func TestNet_NetInterfaceDeleteSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.DeleteNetInterface("C666", "C666-v3666-1.1")
+
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}
+
+func TestNet_NetRouteCreateSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	opts := &netapp.NetRoutesInfo{
+		DestinationAddress: "0.0.0.0/0",
+		GatewayAddress:     "172.30.1.199",
+		Metric:             20,
+		ReturnRecord:       true,
+	}
+
+	call, _, err := c.Net.CreateRoute("C666", opts)
+
+	results := call.Results
+	checkResponseSuccess(&results.SingleResultBase, err, t)
+
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"Address Family", results.Info.AddressFamily, "ipv4"},
+		{"Destination Address", results.Info.DestinationAddress, opts.DestinationAddress},
+		{"Gateway Address", results.Info.GatewayAddress, opts.GatewayAddress},
+		{"Metric", results.Info.Metric, opts.Metric},
+		{"VServer", results.Info.VServer, "C666"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Errorf("Vserver.Get() got = %+v, want %+v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNet_NetRouteDeleteSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Net.DeleteRoute("C666", "0.0.0.0/0", "172.30.1.199")
+
+	results := call.Results
+	checkResponseSuccess(&results.SingleResultBase, err, t)
+}

--- a/netapp/netapp_test.go
+++ b/netapp/netapp_test.go
@@ -47,8 +47,6 @@ func createTestClientWithFixtures(t *testing.T) (c *netapp.Client, teardownFn fu
 
 		if !bytes.Equal(bs, requestFixture) {
 			t.Errorf("%s: result not as expected:\n%v", t.Name(), diff.LineDiff(string(requestFixture), string(bs)))
-			w.WriteHeader(http.StatusServiceUnavailable)
-			return
 		}
 
 		w.WriteHeader(http.StatusOK)
@@ -60,29 +58,17 @@ func createTestClientWithFixtures(t *testing.T) (c *netapp.Client, teardownFn fu
 	return c, teardown
 }
 
-func checkResponseSuccess(result *netapp.SingleResultBase, err error, t *testing.T) {
+func checkResponseSuccess(result netapp.Result, err error, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Should not have gotten an error %s", err)
 	}
 
 	if !result.Passed() {
-		t.Fatalf("Got the failure response, expected success, reason: %s", result.Reason)
+		t.Fatalf("Got the failure response, expected success, reason: %s", result.Result().Reason)
 	}
 }
 
-
-func checkAsyncResponseSuccess(result *netapp.AsyncResultBase, err error, t *testing.T) {
-	if err != nil {
-		t.Fatalf("Async Response should not have gotten an error %s", err)
-	}
-
-	if !result.Passed() {
-		t.Fatalf("Async Response expected success got failure, reason: %s", result.ErrorMessage)
-	}
-}
-
-
-func checkResponseFailure(result *netapp.SingleResultBase, err error, t *testing.T) {
+func checkResponseFailure(result netapp.Result, err error, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Should not have gotten an error %s", err)
 	}

--- a/netapp/qos-policy_test.go
+++ b/netapp/qos-policy_test.go
@@ -6,38 +6,6 @@ import (
 	"github.com/pepabo/go-netapp/netapp"
 )
 
-func checkResponseSuccess(result *netapp.SingleResultBase, err error, t *testing.T) {
-
-	if err != nil {
-		t.Fatalf("Should not have gotten an error %s", err)
-	}
-
-	if !result.Passed() {
-		t.Fatalf("Got the failure response, expected success, reason: %s", result.Reason)
-	}
-}
-
-func checkResponseFailure(result *netapp.SingleResultBase, err error, t *testing.T) {
-	if err != nil {
-		t.Fatalf("Should not have gotten an error %s", err)
-	}
-
-	if result.Passed() {
-		t.Fatal("Got the successful response, expecting failure")
-	}
-}
-
-func testFailureResult(errorNo int, reason string, result *netapp.SingleResultBase, t *testing.T) {
-
-	if result.ErrorNo != errorNo {
-		t.Errorf("%s got = %+v, want %+v", t.Name(), result.ErrorNo, errorNo)
-	}
-
-	if result.Reason != reason {
-		t.Errorf("%s got = %+v, want %+v", t.Name(), result.Reason, reason)
-	}
-}
-
 func TestQosPolicy_GetSuccess(t *testing.T) {
 	c, teardown := createTestClientWithFixtures(t)
 	defer teardown()

--- a/netapp/vserver_test.go
+++ b/netapp/vserver_test.go
@@ -81,7 +81,7 @@ func TestVServer_CreateSuccess(t *testing.T) {
 	}
 
 	call, _, err := c.VServer.Create(vserverSettings)
-	checkAsyncResponseSuccess(&call.Results.AsyncResultBase, err, t)
+	checkResponseSuccess(&call.Results.AsyncResultBase, err, t)
 
 	info := call.Results.VServerInfo
 	job := call.Results.AsyncResultBase


### PR DESCRIPTION
This PR adds the following calls:

- Net.C/R/D/ BroadcastDomain
- Net.C/R/L/U/D/ IPSpace
- Net.C/R/D Vlan
- Net.C/D Network Interface
- Net.C/D Network Route

Also moved some helper test functions and added a base `SingleResultResponse` as a lot of times the api just says "OK Great, good to go". I added a `Result` interface to make checking of results a bit easier and standardized

Of course, everything is also tested.