### PR TITLE
add snapmirror calls

### DIFF
--- a/netapp/fixtures/TestSnapmirror_CreateSuccess_request.xml
+++ b/netapp/fixtures/TestSnapmirror_CreateSuccess_request.xml
@@ -1,0 +1,7 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="C666">
+  <snapmirror-create>
+    <destination-location>C666:c666_root_m1</destination-location>
+    <relationship-type>load_sharing</relationship-type>
+    <source-location>C666:c666_root</source-location>
+  </snapmirror-create>
+</netapp>

--- a/netapp/fixtures/TestSnapmirror_CreateSuccess_response.xml
+++ b/netapp/fixtures/TestSnapmirror_CreateSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of snapmirror-create [Execution Time: 1929 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/fixtures/TestSnapmirror_GetSuccess_request.xml
+++ b/netapp/fixtures/TestSnapmirror_GetSuccess_request.xml
@@ -1,0 +1,13 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="C666">
+  <snapmirror-get>
+    <desired-attributes>
+      <snapmirror-info>
+        <is-healthy>true</is-healthy>
+        <relationship-type> </relationship-type>
+        <vserver> </vserver>
+      </snapmirror-info>
+    </desired-attributes>
+    <destination-location>C666:c666_root_m1</destination-location>
+    <source-location>C666:c666_root</source-location>
+  </snapmirror-get>
+</netapp>

--- a/netapp/fixtures/TestSnapmirror_GetSuccess_response.xml
+++ b/netapp/fixtures/TestSnapmirror_GetSuccess_response.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of snapmirror-get [Execution Time: 384 ms] -->
+	<results status='passed'>
+		<attributes>
+			<snapmirror-info>
+				<destination-cluster>lab-cluster01</destination-cluster>
+				<destination-location>lab-cluster01://C666/c666_root_m1</destination-location>
+				<destination-volume>c666_root_m1</destination-volume>
+				<destination-vserver>C666</destination-vserver>
+				<is-healthy>true</is-healthy>
+        <relationship-type>load_sharing</relationship-type>
+				<source-cluster>lab-cluster01</source-cluster>
+				<source-location>lab-cluster01://C666/c666_root</source-location>
+				<source-volume>c666_root</source-volume>
+				<source-vserver>C666</source-vserver>
+				<vserver>C666</vserver>
+			</snapmirror-info>
+		</attributes>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestSnapmirror_InitializeLSSetSuccess_request.xml
+++ b/netapp/fixtures/TestSnapmirror_InitializeLSSetSuccess_request.xml
@@ -1,0 +1,5 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="C666">
+  <snapmirror-initialize-ls-set>
+    <source-location>C666:c666_root</source-location>
+  </snapmirror-initialize-ls-set>
+</netapp>

--- a/netapp/fixtures/TestSnapmirror_InitializeLSSetSuccess_response.xml
+++ b/netapp/fixtures/TestSnapmirror_InitializeLSSetSuccess_response.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of snapmirror-initialize-ls-set [Execution Time: 441 ms] -->
+	<results status='passed'>
+		<result-jobid>27167</result-jobid>
+		<result-status>in_progress</result-status>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestSnapmirror_UpdateLSSetSuccess_request.xml
+++ b/netapp/fixtures/TestSnapmirror_UpdateLSSetSuccess_request.xml
@@ -1,0 +1,5 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="C666">
+  <snapmirror-update-ls-set>
+    <source-location>C666:c666_root</source-location>
+  </snapmirror-update-ls-set>
+</netapp>

--- a/netapp/fixtures/TestSnapmirror_UpdateLSSetSuccess_response.xml
+++ b/netapp/fixtures/TestSnapmirror_UpdateLSSetSuccess_response.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of snapmirror-update-ls-set [Execution Time: 426 ms] -->
+	<results status='passed'>
+		<result-jobid>27168</result-jobid>
+		<result-status>in_progress</result-status>
+	</results>
+</netapp>

--- a/netapp/fixtures/TestVolumeOperation_CreateSuccess_request.xml
+++ b/netapp/fixtures/TestVolumeOperation_CreateSuccess_request.xml
@@ -1,0 +1,9 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin" vfiler="C666">
+  <volume-create>
+    <containing-aggr-name>n01_aggrfp_sas01</containing-aggr-name>
+    <size>1G</size>
+    <snapshot-policy>none</snapshot-policy>
+    <volume>c666_root_m1</volume>
+    <volume-type>dp</volume-type>
+  </volume-create>
+</netapp>

--- a/netapp/fixtures/TestVolumeOperation_CreateSuccess_response.xml
+++ b/netapp/fixtures/TestVolumeOperation_CreateSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100' xmlns='http://www.netapp.com/filer/admin'>
+
+    <!-- Output of volume-create [Execution Time: 2348 ms] -->
+	<results status='passed'/>
+</netapp>

--- a/netapp/netapp.go
+++ b/netapp/netapp.go
@@ -42,6 +42,7 @@ type Client struct {
 	QuotaReport      *QuotaReport
 	QuotaStatus      *QuotaStatus
 	Snapshot         *Snapshot
+	Snapmirror       *Snapmirror
 	StorageDisk      *StorageDisk
 	System           *System
 	Volume           *Volume
@@ -156,6 +157,10 @@ func NewClient(endpoint string, version string, options *ClientOptions) *Client 
 	}
 
 	c.Snapshot = &Snapshot{
+		Base: b,
+	}
+
+	c.Snapmirror = &Snapmirror{
 		Base: b,
 	}
 

--- a/netapp/netapp_test.go
+++ b/netapp/netapp_test.go
@@ -60,7 +60,7 @@ func createTestClientWithFixtures(t *testing.T) (c *netapp.Client, teardownFn fu
 
 func checkResponseSuccess(result netapp.Result, err error, t *testing.T) {
 	if err != nil {
-		t.Fatalf("Should not have gotten an error %s", err)
+		t.Fatalf("Should not have gotten an error: '%s'", err)
 	}
 
 	if !result.Passed() {

--- a/netapp/snapmirror.go
+++ b/netapp/snapmirror.go
@@ -1,0 +1,171 @@
+package netapp
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+// Snapmirror is Snapmirror API struct
+type Snapmirror struct {
+	Base
+	Params struct {
+		XMLName           xml.Name
+		DesiredAttributes *SnapmirrorInfo `xml:"desired-attributes>snapmirror-info,omitempty"`
+		*SnapmirrorInfo
+	}
+}
+
+// Snapmirror Relationship Types
+const (
+	SnapmirrorRelationshipDP  string = "data_protection"
+	SnapmirrorRelationshipLS  string = "load_sharing"
+	SnapmirrorRelationshipV   string = "vault"
+	SnapmirrorRelationshipR   string = "restore"
+	SnapmirrorRelationshipTDP string = "transition_data_protection"
+	SnapmirrorRelationshipEDP string = "extended_data_protection"
+)
+
+// SnapmirrorInfo contains all fields for snapmirror data
+type SnapmirrorInfo struct {
+	BreakFailedCount                    int      `xml:"break-failed-count,omitempty"`
+	BreakSuccessCount                   int      `xml:"break-successful-count,omitempty"`
+	CGItemMappings                      []string `xml:"cg-item-mappings,omitempty"`
+	CurrentMaxTransferRate              int      `xml:"current-max-transfer-rate,omitempty"`
+	CurrentOperationID                  string   `xml:"current-operation-id,omitempty"`
+	CurrentTransferError                string   `xml:"current-transfer-error,omitempty"`
+	CurrentTransferPriority             string   `xml:"current-transfer-priority,omitempty"`
+	CurrentTransferType                 string   `xml:"current-transfer-type,omitempty"`
+	DestinationCluster                  string   `xml:"destination-cluster,omitempty"`
+	DestinationLocation                 string   `xml:"destination-location,omitempty"`
+	DestinationVolume                   string   `xml:"destination-volume,omitempty"`
+	DestinationVolumeNode               string   `xml:"destination-volume-node,omitempty"`
+	DestinationVServer                  string   `xml:"destination-vserver,omitempty"`
+	ExportedSnapshot                    string   `xml:"exported-snapshot,omitempty"`
+	ExportedSnapshotTimestamp           int      `xml:"exported-snapshot-timestamp,omitempty"`
+	RestoreFileCount                    int      `xml:"file-restore-file-count,omitempty"`
+	RestoreFileList                     []string `xml:"file-restore-file-list,omitempty"`
+	IdentitityPreserve                  bool     `xml:"identity-preserve,omitempty"`
+	IsConstituent                       bool     `xml:"is-constituent,omitempty"`
+	IsHealthy                           bool     `xml:"is-healthy,omitempty"`
+	LagTime                             int      `xml:"lag-time,omitempty"`
+	LastTransferDuration                int      `xml:"last-transfer-duration,omitempty"`
+	LastTransferEndTimestamp            int      `xml:"last-transfer-end-timestamp,omitempty"`
+	LastTransferError                   string   `xml:"last-transfer-error,omitempty"`
+	LastTransferErrorCodes              []int    `xml:"last-transfer-error-codes,omitempty"`
+	LastTransferFrom                    string   `xml:"last-transfer-from,omitempty"`
+	LastTransferNetworkCompressionRatio string   `xml:"last-transfer-network-compression-ratio,omitempty"`
+	LastTransferSize                    int      `xml:"last-transfer-size,omitempty"`
+	LastTransferType                    string   `xml:"last-transfer-type,omitempty"`
+	MaxTransferRate                     int      `xml:"max-transfer-rate,omitempty"`
+	MirrorState                         string   `xml:"mirror-state,omitempty"`
+	NetworkCompressionRatio             string   `xml:"network-compression-ratio,omitempty"`
+	NewestSnapshot                      string   `xml:"newest-snapshot,omitempty"`
+	NewestSnapshotTimestamp             int      `xml:"newest-snapshot-timestamp,omitempty"`
+	Policy                              string   `xml:"policy,omitempty"`
+	PolicyType                          string   `xml:"policy-type,omitempty"`
+	ProgressLastUpdated                 int      `xml:"progress-last-updated,omitempty"`
+	PseudoCommonSnapFailedCount         int      `xml:"pseudo-common-snap-failed-count,omitempty"`
+	PseudoCommonSnapSuccessCount        int      `xml:"pseudo-common-snap-success-count,omitempty"`
+	RelationshipControlPlane            string   `xml:"relationship-control-plane,omitempty"`
+	RelationshipGroupType               string   `xml:"relationship-group-type,omitempty"`
+	RelationshipID                      string   `xml:"relationship-id,omitempty"`
+	RelationshipProgress                int      `xml:"relationship-progress,omitempty"`
+	RelationshipStatus                  string   `xml:"relationship-status,omitempty"`
+	RelationshipType                    string   `xml:"relationship-type,omitempty"`
+	ResyncAvgTimeSyncCg                 int      `xml:"resync-avg-time-sync-cg,omitempty"`
+	ResyncFailedCount                   int      `xml:"resync-failed-count,omitempty"`
+	ResyncSuccessCount                  int      `xml:"resync-successful-count,omitempty"`
+	Schedule                            string   `xml:"schedule,omitempty"`
+	SnapshotCheckpoint                  int      `xml:"snapshot-checkpoint,omitempty"`
+	SnapshotProgress                    int      `xml:"snapshot-progress,omitempty"`
+	SourceCluster                       string   `xml:"source-cluster,omitempty"`
+	SourceLocation                      string   `xml:"source-location,omitempty"`
+	SourceVolume                        string   `xml:"source-volume,omitempty"`
+	SourceVolumeNode                    string   `xml:"source-volume-node,omitempty"`
+	SourceVServer                       string   `xml:"source-vserver,omitempty"`
+	TotalTransferBytes                  int      `xml:"total-transfer-bytes,omitempty"`
+	TotalTransferTime                   int      `xml:"total-transfer-time,omitempty"`
+	TransferSnapshot                    string   `xml:"transfer-snapshot,omitempty"`
+	Tries                               string   `xml:"tries,omitempty"`
+	UnhealthyReason                     string   `xml:"unhealthy-reason,omitempty"`
+	UpdateFailedCount                   int      `xml:"update-failed-count,omitempty"`
+	UpdateSuccessCount                  int      `xml:"update-successful-count,omitempty"`
+	VServer                             string   `xml:"vserver,omitempty"`
+}
+
+// SnapmirrorResponse returns results for snapmirror
+type SnapmirrorResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+		Info *SnapmirrorInfo `xml:"attributes>snapmirror-info"`
+	} `xml:"results"`
+}
+
+type SnapmirrorAsyncResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		AsyncResultBase
+	} `xml:"results"`
+}
+
+// Create creates a snapmirror on a vserver with attributes provided. Note, not all attributes
+// are supported, refer to docs or api errors to diagnose
+func (s Snapmirror) Create(vServerName string, attributes *SnapmirrorInfo) (*SingleResultResponse, *http.Response, error) {
+	s.Name = vServerName
+	s.Params.XMLName = xml.Name{Local: "snapmirror-create"}
+	s.Params.SnapmirrorInfo = attributes
+
+	r := &SingleResultResponse{}
+	res, err := s.get(s, r)
+	return r, res, err
+}
+
+// Get returns data related to a snapmirror
+func (s Snapmirror) Get(vServerName string, sourcePath string, destinationPath string, attributes *SnapmirrorInfo) (*SnapmirrorResponse, *http.Response, error) {
+	s.Name = vServerName
+	s.Params.XMLName = xml.Name{Local: "snapmirror-get"}
+	s.Params.SnapmirrorInfo = &SnapmirrorInfo{
+		DestinationLocation: destinationPath,
+		SourceLocation:      sourcePath,
+	}
+	if attributes == nil {
+		// base response includes source/destination fields only
+		s.Params.DesiredAttributes = &SnapmirrorInfo{
+			IsHealthy:        true,
+			VServer:          " ",
+			RelationshipType: " ",
+		}
+	} else {
+		s.Params.DesiredAttributes = attributes
+	}
+	r := &SnapmirrorResponse{}
+	res, err := s.get(s, r)
+	return r, res, err
+}
+
+// InitializeLSSet starts a Load Sharing set via an async call
+func (s Snapmirror) InitializeLSSet(vServerName string, sourcePath string) (*SnapmirrorAsyncResponse, *http.Response, error) {
+	s.Name = vServerName
+	s.Params.XMLName = xml.Name{Local: "snapmirror-initialize-ls-set"}
+	s.Params.SnapmirrorInfo = &SnapmirrorInfo{
+		SourceLocation: sourcePath,
+	}
+
+	r := &SnapmirrorAsyncResponse{}
+	res, err := s.get(s, r)
+	return r, res, err
+}
+
+// UpdateLSSet starts a Load Sharing set via an async call
+func (s Snapmirror) UpdateLSSet(vServerName string, sourcePath string) (*SnapmirrorAsyncResponse, *http.Response, error) {
+	s.Name = vServerName
+	s.Params.XMLName = xml.Name{Local: "snapmirror-update-ls-set"}
+	s.Params.SnapmirrorInfo = &SnapmirrorInfo{
+		SourceLocation: sourcePath,
+	}
+
+	r := &SnapmirrorAsyncResponse{}
+	res, err := s.get(s, r)
+	return r, res, err
+}

--- a/netapp/snapmirror_test.go
+++ b/netapp/snapmirror_test.go
@@ -61,7 +61,7 @@ func TestSnapmirror_InitializeLSSetSuccess(t *testing.T) {
 	defer teardown()
 
 	call, _, err := c.Snapmirror.InitializeLSSet("C666", "C666:c666_root")
-	checkAsyncResponseSuccess(&call.Results.AsyncResultBase, err, t)
+	checkResponseSuccess(&call.Results.AsyncResultBase, err, t)
 
 	job := call.Results.AsyncResultBase
 	expectedJob := 27167
@@ -79,7 +79,7 @@ func TestSnapmirror_UpdateLSSetSuccess(t *testing.T) {
 	defer teardown()
 
 	call, _, err := c.Snapmirror.UpdateLSSet("C666", "C666:c666_root")
-	checkAsyncResponseSuccess(&call.Results.AsyncResultBase, err, t)
+	checkResponseSuccess(&call.Results.AsyncResultBase, err, t)
 
 	job := call.Results.AsyncResultBase
 	expectedJob := 27168

--- a/netapp/snapmirror_test.go
+++ b/netapp/snapmirror_test.go
@@ -1,0 +1,93 @@
+package netapp_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pepabo/go-netapp/netapp"
+)
+
+func TestSnapmirror_GetSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Snapmirror.Get("C666", "C666:c666_root", "C666:c666_root_m1", nil)
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+
+	info := call.Results.Info
+
+	tests := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"Destination Cluster", info.DestinationCluster, "lab-cluster01"},
+		{"Destination Location", info.DestinationLocation, "lab-cluster01://C666/c666_root_m1"},
+		{"Destination Volume", info.DestinationVolume, "c666_root_m1"},
+		{"Destination VServer", info.DestinationVServer, "C666"},
+		{"Is Healthy", info.IsHealthy, true},
+		{"Relationship Type", info.RelationshipType, "load_sharing"},
+		{"Source Cluster", info.SourceCluster, "lab-cluster01"},
+		{"Source Location", info.SourceLocation, "lab-cluster01://C666/c666_root"},
+		{"Source Volume", info.SourceVolume, "c666_root"},
+		{"Source VServer", info.SourceVServer, "C666"},
+		{"VServer", info.VServer, "C666"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Errorf("Snapmirror.Get() got = %+v, want %+v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSnapmirror_CreateSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	opts := &netapp.SnapmirrorInfo{
+		SourceLocation:      "C666:c666_root",
+		DestinationLocation: "C666:c666_root_m1",
+		RelationshipType:    netapp.SnapmirrorRelationshipLS,
+	}
+	call, _, err := c.Snapmirror.Create("C666", opts)
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}
+
+func TestSnapmirror_InitializeLSSetSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Snapmirror.InitializeLSSet("C666", "C666:c666_root")
+	checkAsyncResponseSuccess(&call.Results.AsyncResultBase, err, t)
+
+	job := call.Results.AsyncResultBase
+	expectedJob := 27167
+	if job.JobID != expectedJob {
+		t.Errorf("Incorrect Job Id. Expected %d, got %d", expectedJob, job.JobID)
+	}
+	expectedStatus := "in_progress"
+	if job.JobStatus != expectedStatus {
+		t.Errorf("Incorrect job status. Exepcted %s, got %s", expectedStatus, job.JobStatus)
+	}
+}
+
+func TestSnapmirror_UpdateLSSetSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.Snapmirror.UpdateLSSet("C666", "C666:c666_root")
+	checkAsyncResponseSuccess(&call.Results.AsyncResultBase, err, t)
+
+	job := call.Results.AsyncResultBase
+	expectedJob := 27168
+	if job.JobID != expectedJob {
+		t.Errorf("Incorrect Job Id. Expected %d, got %d", expectedJob, job.JobID)
+	}
+	expectedStatus := "in_progress"
+	if job.JobStatus != expectedStatus {
+		t.Errorf("Incorrect job status. Exepcted %s, got %s", expectedStatus, job.JobStatus)
+	}
+}

--- a/netapp/volume-operations.go
+++ b/netapp/volume-operations.go
@@ -74,26 +74,18 @@ type VolumeCreateOptions struct {
 	VserverDrProtection        string `xml:"vserver-dr-protection,omitempty"`
 }
 
-// VolumeOperationResponse is a response struct for volume operations
-type VolumeOperationResponse struct {
-	XMLName xml.Name `xml:"netapp"`
-	Results struct {
-		SingleResultBase
-	} `xml:"results"`
-}
-
 // Create a new volume
-func (v VolumeOperation) Create(options *VolumeCreateOptions, vserverName string) (*VolumeOperationResponse, *http.Response, error) {
+func (v VolumeOperation) Create(vserverName string, options *VolumeCreateOptions) (*SingleResultResponse, *http.Response, error) {
 	v.Params.XMLName = xml.Name{Local: VolumeCreateOperation}
 	v.Name = vserverName
 	v.Params.VolumeCreateOptions = *options
-	r := VolumeOperationResponse{}
+	r := SingleResultResponse{}
 	res, err := v.get(v, &r)
 	return &r, res, err
 }
 
 // Operation runs several operations (from consts defined above with VolumeOperation* name)
-func (v VolumeOperation) Operation(volName string, vserverName string, operation string) (*VolumeOperationResponse, *http.Response, error) {
+func (v VolumeOperation) Operation(vserverName string, volName string, operation string) (*SingleResultResponse, *http.Response, error) {
 	v.Params.XMLName = xml.Name{Local: operation}
 	v.Name = vserverName
 	elementName := "name"
@@ -104,7 +96,7 @@ func (v VolumeOperation) Operation(volName string, vserverName string, operation
 		XMLName: xml.Name{Local: elementName},
 		Name:    volName,
 	}
-	r := VolumeOperationResponse{}
+	r := SingleResultResponse{}
 	res, err := v.get(v, &r)
 	return &r, res, err
 }

--- a/netapp/volume-operations_test.go
+++ b/netapp/volume-operations_test.go
@@ -1,0 +1,22 @@
+package netapp_test
+
+import (
+	"testing"
+
+	"github.com/pepabo/go-netapp/netapp"
+)
+
+func TestVolumeOperation_CreateSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	opts := &netapp.VolumeCreateOptions{
+		Volume:                  "c666_root_m1",
+		ContainingAggregateName: "n01_aggrfp_sas01",
+		Size:                    "1G",
+		SnapshotPolicy:          "none",
+		VolumeType:              "dp",
+	}
+	call, _, err := c.VolumeOperations.Create("C666", opts)
+	checkResponseSuccess(&call.Results.SingleResultBase, err, t)
+}

--- a/netapp/vserver_test.go
+++ b/netapp/vserver_test.go
@@ -89,7 +89,7 @@ func TestVServer_CreateSuccess(t *testing.T) {
 	if job.JobID != expectedJob {
 		t.Errorf("Incorrect Job Id. Expected %d, got %d", expectedJob, job.JobID)
 	}
-	// checkJobResponse(job.JobID, 27008)
+
 	if info.VserverName != vserverSettings.VserverName {
 		t.Errorf("Incorrect VServer name. Expected %s, got %s", vserverSettings.VserverName, info.VserverName)
 	}


### PR DESCRIPTION
This PR adds snapmirror create/read calls, LS init/update calls as well as tests for them. It also changes how volume operations parameters are passed in slightly so that vserver is first.