### PR TITLE
Fix vserver create error handling, add vserver delete call

### DIFF
--- a/netapp/base.go
+++ b/netapp/base.go
@@ -40,11 +40,11 @@ type SingleResultResponse struct {
 }
 
 type AsyncResultBase struct {
+	SingleResultBase
 	ErrorCode    int    `xml:"result-error-code"`
 	ErrorMessage string `xml:"result-error-message"`
 	JobID        int    `xml:"result-jobid"`
 	JobStatus    string `xml:"result-status"`
-	Status       string `xml:"status,attr"`
 }
 
 func (r *ResultBase) Passed() bool {
@@ -74,8 +74,8 @@ func (r *AsyncResultBase) Passed() bool {
 func (r *AsyncResultBase) Result() *SingleResultBase {
 	return &SingleResultBase{
 		Status:  r.Status,
-		Reason:  r.ErrorMessage,
-		ErrorNo: r.ErrorCode,
+		Reason:  r.Reason,
+		ErrorNo: r.ErrorNo,
 	}
 }
 

--- a/netapp/fixtures/TestVServer_CreateFailure_request.xml
+++ b/netapp/fixtures/TestVServer_CreateFailure_request.xml
@@ -1,0 +1,10 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <vserver-create-async>
+    <ipspace>test</ipspace>
+    <snapshot-policy>none</snapshot-policy>
+    <vserver-name>TEST</vserver-name>
+    <root-volume>TEST_root</root-volume>
+    <root-volume-aggregate>aggregate</root-volume-aggregate>
+    <root-volume-security-style>unix</root-volume-security-style>
+  </vserver-create-async>
+</netapp>

--- a/netapp/fixtures/TestVServer_CreateFailure_response.xml
+++ b/netapp/fixtures/TestVServer_CreateFailure_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE netapp SYSTEM 'file:/etc/netapp_gx.dtd'>
+<netapp version='1.100'
+  xmlns='http://www.netapp.com/filer/admin'>
+  <results reason="Ipspace &quot;test&quot; does not exist." status="failed" errno="1017"/>
+</netapp>

--- a/netapp/fixtures/TestVServer_DeleteSuccess_request.xml
+++ b/netapp/fixtures/TestVServer_DeleteSuccess_request.xml
@@ -1,0 +1,5 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <vserver-destroy>
+    <vserver-name>T100</vserver-name>
+  </vserver-destroy>
+</netapp>

--- a/netapp/fixtures/TestVServer_DeleteSuccess_response.xml
+++ b/netapp/fixtures/TestVServer_DeleteSuccess_response.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE netapp SYSTEM 'file:/etc/netapp_gx.dtd'>
+<netapp version='1.100'
+  xmlns='http://www.netapp.com/filer/admin'>
+  <results status="passed"/>
+</netapp>

--- a/netapp/netapp_test.go
+++ b/netapp/netapp_test.go
@@ -78,14 +78,14 @@ func checkResponseFailure(result netapp.Result, err error, t *testing.T) {
 	}
 }
 
-func testFailureResult(errorNo int, reason string, result *netapp.SingleResultBase, t *testing.T) {
-
+func testFailureResult(errorNo int, expectedReason string, r netapp.Result, t *testing.T) {
+	result := r.Result()
 	if result.ErrorNo != errorNo {
 		t.Errorf("%s got = %+v, want %+v", t.Name(), result.ErrorNo, errorNo)
 	}
 
-	if result.Reason != reason {
-		t.Errorf("%s got = %+v, want %+v", t.Name(), result.Reason, reason)
+	if result.Reason != expectedReason {
+		t.Errorf("%s got = %+v, want %+v", t.Name(), result.Reason, expectedReason)
 	}
 }
 

--- a/netapp/vserver.go
+++ b/netapp/vserver.go
@@ -106,6 +106,8 @@ func (v VServer) List(options *VServerOptions) (*VServerListResponse, *http.Resp
 }
 
 func (v VServer) Delete(name string) (*VServerListResponse, *http.Response, error) {
+	v.Params.XMLName = xml.Name{Local: "vserver-destroy"}
+	v.Params.VserverName = name
 
 	r := VServerListResponse{}
 	res, err := v.get(v, &r)

--- a/netapp/vserver_test.go
+++ b/netapp/vserver_test.go
@@ -116,3 +116,11 @@ func TestVServer_CreateFailure(t *testing.T) {
 
 	testFailureResult(1017, `Ipspace "test" does not exist.`, results, t)
 }
+
+func TestVServer_DeleteSuccess(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	call, _, err := c.VServer.Delete("T100")
+	checkResponseSuccess(&call.Results.ResultBase, err, t)
+}

--- a/netapp/vserver_test.go
+++ b/netapp/vserver_test.go
@@ -1,6 +1,7 @@
 package netapp_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -93,4 +94,25 @@ func TestVServer_CreateSuccess(t *testing.T) {
 	if info.VserverName != vserverSettings.VserverName {
 		t.Errorf("Incorrect VServer name. Expected %s, got %s", vserverSettings.VserverName, info.VserverName)
 	}
+}
+
+func TestVServer_CreateFailure(t *testing.T) {
+	c, teardown := createTestClientWithFixtures(t)
+	defer teardown()
+
+	opts := &netapp.VServerInfo{
+		VserverName:             "TEST",
+		Ipspace:                 "test",
+		RootVolume:              fmt.Sprintf("%s_root", "TEST"),
+		RootVolumeAggregate:     "aggregate",
+		RootVolumeSecurityStyle: "unix",
+		SnapshotPolicy:          "none",
+	}
+
+	call, _, err := c.VServer.Create(opts)
+
+	results := &call.Results.AsyncResultBase
+	checkResponseFailure(results, err, t)
+
+	testFailureResult(1017, `Ipspace "test" does not exist.`, results, t)
 }


### PR DESCRIPTION
This PR fixes error message handling for failed create calls, adds a delete call test 