### PR TITLE
Add snapmirror iter abort and deleteby calls with tests

### DIFF
--- a/netapp/fixtures/TestSnapmirror_DestroyByFailure_request.xml
+++ b/netapp/fixtures/TestSnapmirror_DestroyByFailure_request.xml
@@ -1,0 +1,11 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <snapmirror-destroy-iter>
+    <continue-on-failure>true</continue-on-failure>
+    <max-records>20</max-records>
+    <query>
+      <snapmirror-info>
+        <vserver>T100</vserver>
+      </snapmirror-info>
+    </query>
+  </snapmirror-destroy-iter>
+</netapp>

--- a/netapp/fixtures/TestSnapmirror_DestroyByFailure_response.xml
+++ b/netapp/fixtures/TestSnapmirror_DestroyByFailure_response.xml
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100'
+  xmlns='http://www.netapp.com/filer/admin'>
+
+  <!-- Output of snapmirror-destroy-iter [Execution Time: 2900 ms] -->
+  <results status='passed'>
+    <failure-list>
+      <snapmirror-destroy-iter-info>
+        <error-code>13001</error-code>
+        <error-message>SnapMirror: error: Failed to change the volume T100_root_m1 to data-protection. (Volume not online)</error-message>
+        <snapmirror-key>
+          <snapmirror-info>
+            <destination-cluster>test-cluster01</destination-cluster>
+            <destination-location>test-cluster01://T100/T100_root_m1</destination-location>
+            <destination-volume>T100_root_m1</destination-volume>
+            <destination-vserver>T100</destination-vserver>
+            <source-cluster>test-cluster01</source-cluster>
+            <source-location>test-cluster01://T100/T100_root</source-location>
+            <source-volume>T100_root</source-volume>
+            <source-vserver>T100</source-vserver>
+          </snapmirror-info>
+        </snapmirror-key>
+      </snapmirror-destroy-iter-info>
+      <snapmirror-destroy-iter-info>
+        <error-code>13001</error-code>
+        <error-message>SnapMirror: error: Failed to change the volume T100_root_m2 to data-protection. (Volume not online)</error-message>
+        <snapmirror-key>
+          <snapmirror-info>
+            <destination-cluster>test-cluster01</destination-cluster>
+            <destination-location>test-cluster01://T100/T100_root_m2</destination-location>
+            <destination-volume>T100_root_m2</destination-volume>
+            <destination-vserver>T100</destination-vserver>
+            <source-cluster>test-cluster01</source-cluster>
+            <source-location>test-cluster01://T100/T100_root</source-location>
+            <source-volume>T100_root</source-volume>
+            <source-vserver>T100</source-vserver>
+          </snapmirror-info>
+        </snapmirror-key>
+      </snapmirror-destroy-iter-info>
+    </failure-list>
+    <num-failed>2</num-failed>
+    <num-succeeded>0</num-succeeded>
+    <success-list/>
+  </results>
+</netapp>

--- a/netapp/fixtures/TestSnapmirror_DestroyBySuccess_request.xml
+++ b/netapp/fixtures/TestSnapmirror_DestroyBySuccess_request.xml
@@ -1,0 +1,11 @@
+<netapp version="1.10" xmlsns="http://www.netapp.com/filer/admin">
+  <snapmirror-destroy-iter>
+    <continue-on-failure>true</continue-on-failure>
+    <max-records>20</max-records>
+    <query>
+      <snapmirror-info>
+        <vserver>T100</vserver>
+      </snapmirror-info>
+    </query>
+  </snapmirror-destroy-iter>
+</netapp>

--- a/netapp/fixtures/TestSnapmirror_DestroyBySuccess_response.xml
+++ b/netapp/fixtures/TestSnapmirror_DestroyBySuccess_response.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<netapp version='1.100'
+  xmlns='http://www.netapp.com/filer/admin'>
+
+  <!-- Output of snapmirror-destroy-iter [Execution Time: 9003 ms] -->
+  <results status='passed'>
+    <failure-list/>
+    <num-failed>0</num-failed>
+    <num-succeeded>2</num-succeeded>
+    <success-list>
+      <snapmirror-destroy-iter-info>
+        <result-operation-id>00000000-0000-0000-0000-000000000000</result-operation-id>
+        <snapmirror-key>
+          <snapmirror-info>
+            <destination-cluster>test-cluster01</destination-cluster>
+            <destination-location>test-cluster01://T100/T100_root_m1</destination-location>
+            <destination-volume>T100_root_m1</destination-volume>
+            <destination-vserver>T100</destination-vserver>
+            <source-cluster>test-cluster01</source-cluster>
+            <source-location>test-cluster01://T100/T100_root</source-location>
+            <source-volume>T100_root</source-volume>
+            <source-vserver>T100</source-vserver>
+          </snapmirror-info>
+        </snapmirror-key>
+      </snapmirror-destroy-iter-info>
+      <snapmirror-destroy-iter-info>
+        <result-operation-id>00000000-0000-0000-0000-000000000000</result-operation-id>
+        <snapmirror-key>
+          <snapmirror-info>
+            <destination-cluster>test-cluster01</destination-cluster>
+            <destination-location>test-cluster01://T100/T100_root_m2</destination-location>
+            <destination-volume>T100_root_m2</destination-volume>
+            <destination-vserver>T100</destination-vserver>
+            <source-cluster>test-cluster01</source-cluster>
+            <source-location>test-cluster01://T100/T100_root</source-location>
+            <source-volume>T100_root</source-volume>
+            <source-vserver>T100</source-vserver>
+          </snapmirror-info>
+        </snapmirror-key>
+      </snapmirror-destroy-iter-info>
+    </success-list>
+  </results>
+</netapp>


### PR DESCRIPTION
This PR adds snapmirror iter abort/delete calls. 