### PR TITLE
Ad support for Logical Volumes

### DIFF
--- a/netapp/volume.go
+++ b/netapp/volume.go
@@ -159,6 +159,10 @@ type VolumeSpaceAttributes struct {
 	IsFilesysSizeFixed              string `xml:"is-filesys-size-fixed,omitempty"`
 	IsSpaceGuaranteeEnabled         string `xml:"is-space-guarantee-enabled,omitempty"`
 	IsSpaceSloEnabled               string `xml:"is-space-slo-enabled,omitempty"`
+	LogicalUsed						string `xml:"logical-used"`
+	LogicalUsedByAfs				string `xml:"logical-used-by-afs"`
+	LogicalUsedBySnapshot			string `xml:"logical-used-by-snapshot"`
+	LogicalUsedPercent				string `xml:"logical-used-percent"`
 	OverwriteReserve                string `xml:"overwrite-reserve,omitempty"`
 	OverwriteReserveRequired        string `xml:"overwrite-reserve-required,omitempty"`
 	OverwriteReserveUsed            string `xml:"overwrite-reserve-used,omitempty"`

--- a/netapp/volume.go
+++ b/netapp/volume.go
@@ -159,10 +159,10 @@ type VolumeSpaceAttributes struct {
 	IsFilesysSizeFixed              string `xml:"is-filesys-size-fixed,omitempty"`
 	IsSpaceGuaranteeEnabled         string `xml:"is-space-guarantee-enabled,omitempty"`
 	IsSpaceSloEnabled               string `xml:"is-space-slo-enabled,omitempty"`
-	LogicalUsed						string `xml:"logical-used,omitempty"`
-	LogicalUsedByAfs				string `xml:"logical-used-by-afs,omitempty"`
-	LogicalUsedBySnapshot			string `xml:"logical-used-by-snapshot,omitempty"`
-	LogicalUsedPercent				string `xml:"logical-used-percent,omitempty"`
+	LogicalUsed			string `xml:"logical-used,omitempty"`
+	LogicalUsedByAfs		string `xml:"logical-used-by-afs,omitempty"`
+	LogicalUsedBySnapshot		string `xml:"logical-used-by-snapshot,omitempty"`
+	LogicalUsedPercent		string `xml:"logical-used-percent,omitempty"`
 	OverwriteReserve                string `xml:"overwrite-reserve,omitempty"`
 	OverwriteReserveRequired        string `xml:"overwrite-reserve-required,omitempty"`
 	OverwriteReserveUsed            string `xml:"overwrite-reserve-used,omitempty"`

--- a/netapp/volume.go
+++ b/netapp/volume.go
@@ -159,10 +159,10 @@ type VolumeSpaceAttributes struct {
 	IsFilesysSizeFixed              string `xml:"is-filesys-size-fixed,omitempty"`
 	IsSpaceGuaranteeEnabled         string `xml:"is-space-guarantee-enabled,omitempty"`
 	IsSpaceSloEnabled               string `xml:"is-space-slo-enabled,omitempty"`
-	LogicalUsed						string `xml:"logical-used"`
-	LogicalUsedByAfs				string `xml:"logical-used-by-afs"`
-	LogicalUsedBySnapshot			string `xml:"logical-used-by-snapshot"`
-	LogicalUsedPercent				string `xml:"logical-used-percent"`
+	LogicalUsed						string `xml:"logical-used,omitempty"`
+	LogicalUsedByAfs				string `xml:"logical-used-by-afs,omitempty"`
+	LogicalUsedBySnapshot			string `xml:"logical-used-by-snapshot,omitempty"`
+	LogicalUsedPercent				string `xml:"logical-used-percent,omitempty"`
 	OverwriteReserve                string `xml:"overwrite-reserve,omitempty"`
 	OverwriteReserveRequired        string `xml:"overwrite-reserve-required,omitempty"`
 	OverwriteReserveUsed            string `xml:"overwrite-reserve-used,omitempty"`


### PR DESCRIPTION
There are fields related to logical volume sizes which can be good to track. The data is in the XML response, just needs to be added to the VolumeSpaceAttributes struct