### PR TITLE
Igroup initiator add/remove and list export rules

### DIFF
--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -63,14 +63,15 @@ func (v VServer) DeleteExportRule(vServerName string, policyName string, ruleInd
 	res, err := v.get(req, r)
 	return r, res, err
 }
+
 // DeleteExportRule removes an export rule for a given vserver, policy and rule index
-func (v VServer) DeleteExportRuleByClientMatch(vServerName string, policyName string clientMatch string) (*VServerExportsResponse, *http.Response, error) {
+func (v VServer) DeleteExportRuleByClientMatch(vServerName string, policyName string, clientMatch string) (*VServerExportsResponse, *http.Response, error) {
 	req := v.newVServerExportsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "export-rule-destroy"}
 	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{
-		PolicyName: policyName,
-		ClientMatch:  clientMatch,
+		PolicyName:  policyName,
+		ClientMatch: clientMatch,
 	}
 
 	r := &VServerExportsResponse{}

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -13,6 +13,10 @@ type vServerExportsRequest struct {
 	}
 }
 
+type ExportRuleQuery struct {
+	ExportRuleInfo *VServerExportRuleInfo `xml:"export-rule-info,omitempty"`
+}
+
 // VServerExportRuleInfo sets all different options for Export Rules
 type VServerExportRuleInfo struct {
 	AnonymousUserID           int       `xml:"anonymous-user-id,omitempty"`
@@ -35,6 +39,29 @@ type VServerExportsResponse struct {
 	Results struct {
 		SingleResultBase
 	} `xml:"results"`
+}
+
+type ExportRuleListResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		ResultBase
+		AttributesList struct {
+			VServerExportRuleInfo []VServerExportRuleInfo `xml:"export-rule-info"`
+		} `xml:"attributes-list"`
+	} `xml:"results"`
+}
+
+func (v VServer) ListExportRules(vServerName string, exportPolicy string) (*ExportRuleListResponse, *http.Response, error) {
+	req := v.newVServerExportsRequest()
+	req.Base.Name = vServerName
+	req.Params.XMLName = xml.Name{Local: "export-rule-get-iter"}
+	req.Params.VServerExportRuleInfo = &{
+		PolicyName: exportPolicy,
+	}
+
+	r := &ExportRuleListResponse{}
+	res, err = req.get(req, &r)
+	return &r, res, err
 }
 
 // CreateExportRule creates a new export rule for a given vserver

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -37,6 +37,29 @@ type VServerExportsResponse struct {
 	} `xml:"results"`
 }
 
+type VServerExportRuleListResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		ResultBase
+		AttributesList struct {
+			VserverExportRuleInfo []VServerExportRuleInfo `xml:"export-rule-info"`
+		} `xml:"attributes-list"`
+	} `xml:"results"`
+}
+
+// ListExportRules list the rules of an export policy
+func (v Vserver) ListExportRules(vServerName string, exportPolicy string, options *VServerExportRuleInfo) (*VServerExportRuleListResponse, *http.Response, error) {
+	v.Name = vServerName
+	v.Params.XMLName = xml.Name{Local: "export-rule-get-iter"}
+	v.Params.VServerExportRuleInfo = VServerExportRuleInfo{
+		PolicyName: exportPolicy,
+	}
+
+	r := VServerExportRuleListResponse{}
+	res, err := v.get(v, &r)
+	return &r, res, err
+}
+
 // CreateExportRule creates a new export rule for a given vserver
 func (v VServer) CreateExportRule(vServerName string, options *VServerExportRuleInfo) (*VServerExportsResponse, *http.Response, error) {
 	req := v.newVServerExportsRequest()
@@ -57,21 +80,6 @@ func (v VServer) DeleteExportRule(vServerName string, policyName string, ruleInd
 	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{
 		PolicyName: policyName,
 		RuleIndex:  ruleIndex,
-	}
-
-	r := &VServerExportsResponse{}
-	res, err := v.get(req, r)
-	return r, res, err
-}
-
-// DeleteExportRule removes an export rule for a given vserver, policy and rule index
-func (v VServer) DeleteExportRuleByClientMatch(vServerName string, policyName string, clientMatch string) (*VServerExportsResponse, *http.Response, error) {
-	req := v.newVServerExportsRequest()
-	req.Base.Name = vServerName
-	req.Params.XMLName = xml.Name{Local: "export-rule-destroy"}
-	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{
-		PolicyName:  policyName,
-		ClientMatch: clientMatch,
 	}
 
 	r := &VServerExportsResponse{}

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -13,10 +13,6 @@ type vServerExportsRequest struct {
 	}
 }
 
-type VServerExportRuleQuery struct {
-	VServerExportRuleInfo *LunInfo `xml:"export-rule-info,omitempty"`
-}
-
 // VServerExportRuleInfo sets all different options for Export Rules
 type VServerExportRuleInfo struct {
 	AnonymousUserID           int       `xml:"anonymous-user-id,omitempty"`
@@ -39,36 +35,6 @@ type VServerExportsResponse struct {
 	Results struct {
 		SingleResultBase
 	} `xml:"results"`
-}
-
-type VServerExportRuleListResponse struct {
-	XMLName xml.Name `xml:"netapp"`
-	Results struct {
-		ResultBase
-		AttributesList struct {
-			VserverExportRuleInfo []VServerExportRuleInfo `xml:"export-rule-info"`
-		} `xml:"attributes-list"`
-		NextTag    string `xml:"next-tag"`
-		NumRecords int    `xml:"num-records"`
-	} `xml:"results"`
-}
-
-type VServerExportRuleListPagesResponse struct {
-	Response    *LunListResponse
-	Error       error
-	RawResponse *http.Response
-}
-
-// ListExportRules list the rules of an export policy
-func (v VServer) ListExportRules(vServerName string, exportPolicy string, options *VServerExportRuleInfo) (*VServerExportRuleListResponse, *http.Response, error) {
-	v.Params.XMLName = xml.Name{Local: "export-rule-get-iter"}
-	v.Params.VServerExportRuleInfo = VServerExportRuleInfo{
-		PolicyName: exportPolicy,
-	}
-
-	r := VServerExportRuleListResponse{}
-	res, err := v.get(v, &r)
-	return &r, res, err
 }
 
 // CreateExportRule creates a new export rule for a given vserver

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -56,7 +56,7 @@ func (v VServer) ListExportRules(vServerName string, exportPolicy string) (*Expo
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "export-rule-get-iter"}
 	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{
-		PolicyName: exportPolicy,
+		// PolicyName: exportPolicy,
 	}
 
 	r := &ExportRuleListResponse{}
@@ -82,8 +82,8 @@ func (v VServer) DeleteExportRule(vServerName string, policyName string, ruleInd
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "export-rule-destroy"}
 	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{
-		// PolicyName: policyName,
-		RuleIndex: ruleIndex,
+		PolicyName: policyName,
+		RuleIndex:  ruleIndex,
 	}
 
 	r := &VServerExportsResponse{}

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -52,7 +52,7 @@ type ExportRuleListResponse struct {
 }
 
 // ListExportRules lists all export rules on a vserver
-func (v VServer) ListExportRules(vServerName string) (*[]VServerExportRuleInfo, *http.Response, error) {
+func (v VServer) ListExportRules(vServerName string) (*ExportRuleListResponse, *http.Response, error) {
 	req := v.newVServerExportsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "export-rule-get-iter"}

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -61,7 +61,6 @@ type VServerExportRuleListPagesResponse struct {
 
 // ListExportRules list the rules of an export policy
 func (v VServer) ListExportRules(vServerName string, exportPolicy string, options *VServerExportRuleInfo) (*VServerExportRuleListResponse, *http.Response, error) {
-	v.Name = vServerName
 	v.Params.XMLName = xml.Name{Local: "export-rule-get-iter"}
 	v.Params.VServerExportRuleInfo = VServerExportRuleInfo{
 		PolicyName: exportPolicy,

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -55,12 +55,12 @@ func (v VServer) ListExportRules(vServerName string, exportPolicy string) (*Expo
 	req := v.newVServerExportsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "export-rule-get-iter"}
-	req.Params.VServerExportRuleInfo = &VServerExportRuleInfo{
+	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{
 		PolicyName: exportPolicy,
 	}
 
 	r := &ExportRuleListResponse{}
-	res, err = req.get(req, &r)
+	res, err := req.get(req, &r)
 	return &r, res, err
 }
 

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -11,7 +11,11 @@ type vServerExportsRequest struct {
 		XMLName               xml.Name
 		VServerExportRuleInfo `xml:",innerxml"`
 	}
+}type  VServerExportRuleQuery struct {
+	VServerExportRuleInfo *LunInfo `xml:"export-rule-info,omitempty"`
 }
+
+
 
 // VServerExportRuleInfo sets all different options for Export Rules
 type VServerExportRuleInfo struct {
@@ -44,7 +48,15 @@ type VServerExportRuleListResponse struct {
 		AttributesList struct {
 			VserverExportRuleInfo []VServerExportRuleInfo `xml:"export-rule-info"`
 		} `xml:"attributes-list"`
+		NextTag    string `xml:"next-tag"`
+		NumRecords int    `xml:"num-records"`
 	} `xml:"results"`
+}
+
+type VServerExportRuleListPagesResponse struct {
+	Response    *LunListResponse
+	Error       error
+	RawResponse *http.Response
 }
 
 // ListExportRules list the rules of an export policy

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -61,7 +61,7 @@ func (v VServer) ListExportRules(vServerName string, exportPolicy string) (*Expo
 
 	r := &ExportRuleListResponse{}
 	res, err := req.get(req, &r)
-	return &r, res, err
+	return r, res, err
 }
 
 // CreateExportRule creates a new export rule for a given vserver

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -11,11 +11,11 @@ type vServerExportsRequest struct {
 		XMLName               xml.Name
 		VServerExportRuleInfo `xml:",innerxml"`
 	}
-}type  VServerExportRuleQuery struct {
-	VServerExportRuleInfo *LunInfo `xml:"export-rule-info,omitempty"`
 }
 
-
+type VServerExportRuleQuery struct {
+	VServerExportRuleInfo *LunInfo `xml:"export-rule-info,omitempty"`
+}
 
 // VServerExportRuleInfo sets all different options for Export Rules
 type VServerExportRuleInfo struct {

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -51,14 +51,12 @@ type ExportRuleListResponse struct {
 	} `xml:"results"`
 }
 
-func (v VServer) ListExportRules(vServerName string, exportPolicy string) (*ExportRuleListResponse, *http.Response, error) {
+// ListExportRules lists all export rules on a vserver
+func (v VServer) ListExportRules(vServerName string) (*[]VServerExportRuleInfo, *http.Response, error) {
 	req := v.newVServerExportsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "export-rule-get-iter"}
-	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{
-		// PolicyName: exportPolicy,
-	}
-
+	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{}
 	r := &ExportRuleListResponse{}
 	res, err := req.get(req, r)
 	return r, res, err

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -55,7 +55,7 @@ func (v VServer) ListExportRules(vServerName string, exportPolicy string) (*Expo
 	req := v.newVServerExportsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "export-rule-get-iter"}
-	req.Params.VServerExportRuleInfo = &{
+	req.Params.VServerExportRuleInfo = &VServerExportRuleInfo{
 		PolicyName: exportPolicy,
 	}
 

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -48,7 +48,7 @@ type VServerExportRuleListResponse struct {
 }
 
 // ListExportRules list the rules of an export policy
-func (v Vserver) ListExportRules(vServerName string, exportPolicy string, options *VServerExportRuleInfo) (*VServerExportRuleListResponse, *http.Response, error) {
+func (v VServer) ListExportRules(vServerName string, exportPolicy string, options *VServerExportRuleInfo) (*VServerExportRuleListResponse, *http.Response, error) {
 	v.Name = vServerName
 	v.Params.XMLName = xml.Name{Local: "export-rule-get-iter"}
 	v.Params.VServerExportRuleInfo = VServerExportRuleInfo{

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -60,7 +60,7 @@ func (v VServer) ListExportRules(vServerName string, exportPolicy string) (*Expo
 	}
 
 	r := &ExportRuleListResponse{}
-	res, err := req.get(req, &r)
+	res, err := req.get(req, r)
 	return r, res, err
 }
 

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -82,8 +82,8 @@ func (v VServer) DeleteExportRule(vServerName string, policyName string, ruleInd
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "export-rule-destroy"}
 	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{
-		PolicyName: policyName,
-		RuleIndex:  ruleIndex,
+		// PolicyName: policyName,
+		RuleIndex: ruleIndex,
 	}
 
 	r := &VServerExportsResponse{}

--- a/netapp/vserver-exports.go
+++ b/netapp/vserver-exports.go
@@ -63,6 +63,20 @@ func (v VServer) DeleteExportRule(vServerName string, policyName string, ruleInd
 	res, err := v.get(req, r)
 	return r, res, err
 }
+// DeleteExportRule removes an export rule for a given vserver, policy and rule index
+func (v VServer) DeleteExportRuleByClientMatch(vServerName string, policyName string clientMatch string) (*VServerExportsResponse, *http.Response, error) {
+	req := v.newVServerExportsRequest()
+	req.Base.Name = vServerName
+	req.Params.XMLName = xml.Name{Local: "export-rule-destroy"}
+	req.Params.VServerExportRuleInfo = VServerExportRuleInfo{
+		PolicyName: policyName,
+		ClientMatch:  clientMatch,
+	}
+
+	r := &VServerExportsResponse{}
+	res, err := v.get(req, r)
+	return r, res, err
+}
 
 func (v VServer) newVServerExportsRequest() *vServerExportsRequest {
 	return &vServerExportsRequest{

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -1,0 +1,76 @@
+package netapp
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+type vServerIgroupsRequest struct {
+	Base
+	Params struct {
+		XMLName           xml.Name
+		VServerIgroupInfo `xml:",innerxml"`
+	}
+}
+
+type vServerIgroupInfo struct {
+	Base
+	Params struct {
+		XMLName           xml.Name
+		VServerIgroupInfo `xml:",innerxml"`
+	}
+}
+
+// VServerIgroupInfo sets all different options for the igroup
+type VServerIgroupInfo struct {
+	PortsetName        string    `xml:"initiator-group-portset-name,omitempty`
+	InitiatorGroupName string    `xml:"initiator-group-name,omitempty`
+	InitiatorGroupUUID string    `xml:"initiator-group-uuid,omitempty"`
+	Initators          *[]string `xml:"initiators>initiator-name,omitempty"`
+}
+
+// VServerIgroupsResponse creates correct response obj
+type VServerIgroupsResponse struct {
+	XMLName xml.Name `xml:"netapp"`
+	Results struct {
+		SingleResultBase
+	} `xml:"results"`
+}
+
+// AddInitiator add an initiator to an igroup
+func (v Vserver) AddInitiator(vServerName string, iGroupName string, initiator string,
+	options *VServerIgroupInfo) (*VServerIgroupsResponse, *http.Response, error) 
+	{
+		req := v.newVServerIgroupsRequest()
+		req.Base.Name = vServerName
+		req.Params.XMLName = xml.Name{Local: "igroup-add"}
+		req.Params.VServerIgroupInfo = *options
+
+		r := &VServerIgroupsResponse{}
+		res, err := v.get(req, r)
+		return r, res, err
+}
+
+RemoveInitiator add an initiator to an igroup
+func (v Vserver) RemoveInitiator(vServerName string, iGroupName string, initiators *[]string)
+ (*VServerIgroupsResponse, *http.Response, error) {
+	 		req := v.newVServerIgroupsRequest()
+		req.Base.Name = vServerName
+		req.Params.XMLName = xml.Name{Local: "igroup-remove"}
+		req.Params.VServerIgroupInfo = VServerIgroupInfo{
+			InitiatorGroupName: iGroupName,
+			initiators: initiators,
+		}
+
+		r := &VServerIgroupsResponse{}
+		res, err := v.get(req, r)
+		return r, res, err
+	
+
+}
+
+func (v VServer) newVServerIgroupsRequest() *vServerIgroupsRequest {
+	return &vServerIgroupsRequest{
+		Base: v.Base,
+	}
+}

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -38,13 +38,16 @@ type VServerIgroupsResponse struct {
 }
 
 // AddInitiator add an initiator to an igroup
-func (v Vserver) AddInitiator(vServerName string, iGroupName string, initiator string,
+func (v Vserver) AddInitiator(vServerName string, iGroupName string, initiators *[]string,
 	options *VServerIgroupInfo) (*VServerIgroupsResponse, *http.Response, error) 
 	{
 		req := v.newVServerIgroupsRequest()
 		req.Base.Name = vServerName
 		req.Params.XMLName = xml.Name{Local: "igroup-add"}
-		req.Params.VServerIgroupInfo = *options
+		req.Params.VServerIgroupInfo = VServerIgroupInfo{
+			InitiatorGroupName: iGroupName,
+			Initiators: initiators
+		}
 
 		r := &VServerIgroupsResponse{}
 		res, err := v.get(req, r)
@@ -59,7 +62,7 @@ func (v Vserver) RemoveInitiator(vServerName string, iGroupName string, initiato
 		req.Params.XMLName = xml.Name{Local: "igroup-remove"}
 		req.Params.VServerIgroupInfo = VServerIgroupInfo{
 			InitiatorGroupName: iGroupName,
-			initiators: initiators,
+			Initiators: initiators,
 		}
 
 		r := &VServerIgroupsResponse{}

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -28,7 +28,7 @@ type VServerIgroupInfo struct {
 	InitiatorGroupUUID string `xml:"initiator-group-uuid,omitempty"`
 	//Initiators         *[]string `xml:"initiators>initiator-info,omitempty"`
 	InitiatorName string `xml:"initiator,omitempty"`
-	Force         bool   `xml:"force_remove,omitempty"`
+	Force         bool   `xml:"force,omitempty"`
 }
 
 // VServerIgroupsResponse creates correct response obj

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -23,8 +23,8 @@ type vServerIgroupInfo struct {
 
 // VServerIgroupInfo sets all different options for the igroup
 type VServerIgroupInfo struct {
-	PortsetName        string    `xml:"initiator-group-portset-name,omitempty`
-	InitiatorGroupName string    `xml:"initiator-group-name,omitempty`
+	PortsetName        string    `xml:"initiator-group-portset-name,omitempty"`
+	InitiatorGroupName string    `xml:"initiator-group-name,omitempty"`
 	InitiatorGroupUUID string    `xml:"initiator-group-uuid,omitempty"`
 	Initiators         *[]string `xml:"initiators>initiator-name,omitempty"`
 }

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -38,7 +38,7 @@ type VServerIgroupsResponse struct {
 }
 
 // AddInitiator add an initiator to an igroup
-func (v Vserver) AddInitiator(vServerName string, iGroupName string, initiators *[]string, options *VServerIgroupInfo) (*VServerIgroupsResponse, *http.Response, error) {
+func (v VServer) AddInitiator(vServerName string, iGroupName string, initiators *[]string, options *VServerIgroupInfo) (*VServerIgroupsResponse, *http.Response, error) {
 	req := v.newVServerIgroupsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "igroup-add"}
@@ -53,7 +53,7 @@ func (v Vserver) AddInitiator(vServerName string, iGroupName string, initiators 
 }
 
 // RemoveInitiator add an initiator to an igroup
-func (v Vserver) RemoveInitiator(vServerName string, iGroupName string, initiators *[]string) (*VServerIgroupsResponse, *http.Response, error) {
+func (v VServer) RemoveInitiator(vServerName string, iGroupName string, initiators *[]string) (*VServerIgroupsResponse, *http.Response, error) {
 	req := v.newVServerIgroupsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "igroup-remove"}

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -38,9 +38,7 @@ type VServerIgroupsResponse struct {
 }
 
 // AddInitiator add an initiator to an igroup
-func (v Vserver) AddInitiator(vServerName string, iGroupName string, initiators *[]string,
-	options *VServerIgroupInfo) (*VServerIgroupsResponse, *http.Response, error) 
-	{
+func (v Vserver) AddInitiator(vServerName string, iGroupName string, initiators *[]string, options *VServerIgroupInfo) (*VServerIgroupsResponse, *http.Response, error) {
 		req := v.newVServerIgroupsRequest()
 		req.Base.Name = vServerName
 		req.Params.XMLName = xml.Name{Local: "igroup-add"}
@@ -55,8 +53,7 @@ func (v Vserver) AddInitiator(vServerName string, iGroupName string, initiators 
 }
 
 RemoveInitiator add an initiator to an igroup
-func (v Vserver) RemoveInitiator(vServerName string, iGroupName string, initiators *[]string)
- (*VServerIgroupsResponse, *http.Response, error) {
+func (v Vserver) RemoveInitiator(vServerName string, iGroupName string, initiators *[]string) (*VServerIgroupsResponse, *http.Response, error) {
 	 		req := v.newVServerIgroupsRequest()
 		req.Base.Name = vServerName
 		req.Params.XMLName = xml.Name{Local: "igroup-remove"}

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -38,7 +38,7 @@ type VServerIgroupsResponse struct {
 }
 
 // AddInitiator add an initiator to an igroup
-func (v VServer) AddInitiator(vServerName string, iGroupName string, initiators *[]string, options *VServerIgroupInfo) (*VServerIgroupsResponse, *http.Response, error) {
+func (v VServer) AddInitiator(vServerName string, iGroupName string, initiators *[]string) (*VServerIgroupsResponse, *http.Response, error) {
 	req := v.newVServerIgroupsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "igroup-add"}

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -26,7 +26,7 @@ type VServerIgroupInfo struct {
 	PortsetName        string    `xml:"initiator-group-portset-name,omitempty`
 	InitiatorGroupName string    `xml:"initiator-group-name,omitempty`
 	InitiatorGroupUUID string    `xml:"initiator-group-uuid,omitempty"`
-	Initators          *[]string `xml:"initiators>initiator-name,omitempty"`
+	Initiators         *[]string `xml:"initiators>initiator-name,omitempty"`
 }
 
 // VServerIgroupsResponse creates correct response obj

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -39,33 +39,32 @@ type VServerIgroupsResponse struct {
 
 // AddInitiator add an initiator to an igroup
 func (v Vserver) AddInitiator(vServerName string, iGroupName string, initiators *[]string, options *VServerIgroupInfo) (*VServerIgroupsResponse, *http.Response, error) {
-		req := v.newVServerIgroupsRequest()
-		req.Base.Name = vServerName
-		req.Params.XMLName = xml.Name{Local: "igroup-add"}
-		req.Params.VServerIgroupInfo = VServerIgroupInfo{
-			InitiatorGroupName: iGroupName,
-			Initiators: initiators
-		}
+	req := v.newVServerIgroupsRequest()
+	req.Base.Name = vServerName
+	req.Params.XMLName = xml.Name{Local: "igroup-add"}
+	req.Params.VServerIgroupInfo = VServerIgroupInfo{
+		InitiatorGroupName: iGroupName,
+		Initiators:         initiators,
+	}
 
-		r := &VServerIgroupsResponse{}
-		res, err := v.get(req, r)
-		return r, res, err
+	r := &VServerIgroupsResponse{}
+	res, err := v.get(req, r)
+	return r, res, err
 }
 
-RemoveInitiator add an initiator to an igroup
+// RemoveInitiator add an initiator to an igroup
 func (v Vserver) RemoveInitiator(vServerName string, iGroupName string, initiators *[]string) (*VServerIgroupsResponse, *http.Response, error) {
-	 		req := v.newVServerIgroupsRequest()
-		req.Base.Name = vServerName
-		req.Params.XMLName = xml.Name{Local: "igroup-remove"}
-		req.Params.VServerIgroupInfo = VServerIgroupInfo{
-			InitiatorGroupName: iGroupName,
-			Initiators: initiators,
-		}
+	req := v.newVServerIgroupsRequest()
+	req.Base.Name = vServerName
+	req.Params.XMLName = xml.Name{Local: "igroup-remove"}
+	req.Params.VServerIgroupInfo = VServerIgroupInfo{
+		InitiatorGroupName: iGroupName,
+		Initiators:         initiators,
+	}
 
-		r := &VServerIgroupsResponse{}
-		res, err := v.get(req, r)
-		return r, res, err
-	
+	r := &VServerIgroupsResponse{}
+	res, err := v.get(req, r)
+	return r, res, err
 
 }
 

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -54,12 +54,13 @@ func (v VServer) AddInitiator(vServerName string, iGroupName string, initiator s
 }
 
 // RemoveInitiator add an initiator to an igroup
-func (v VServer) RemoveInitiator(vServerName string, iGroupName string, initiators *[]string) (*VServerIgroupsResponse, *http.Response, error) {
+func (v VServer) RemoveInitiator(vServerName string, iGroupName string, initiator string) (*VServerIgroupsResponse, *http.Response, error) {
 	req := v.newVServerIgroupsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "igroup-remove"}
 	req.Params.VServerIgroupInfo = VServerIgroupInfo{
 		InitiatorGroupName: iGroupName,
+		InitiatorName:      initiator,
 	}
 
 	r := &VServerIgroupsResponse{}

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -23,11 +23,11 @@ type vServerIgroupInfo struct {
 
 // VServerIgroupInfo sets all different options for the igroup
 type VServerIgroupInfo struct {
-	PortsetName        string    `xml:"initiator-group-portset-name,omitempty"`
-	InitiatorGroupName string    `xml:"initiator-group-name,omitempty"`
-	InitiatorGroupUUID string    `xml:"initiator-group-uuid,omitempty"`
-	Initiators         *[]string `xml:"initiators>initiator-info,omitempty"`
-	InitiatorName      string    `xml:"initiators>initiator-info>initiator-name,omitempty"`
+	PortsetName        string `xml:"initiator-group-portset-name,omitempty"`
+	InitiatorGroupName string `xml:"initiator-group-name,omitempty"`
+	InitiatorGroupUUID string `xml:"initiator-group-uuid,omitempty"`
+	//Initiators         *[]string `xml:"initiators>initiator-info,omitempty"`
+	InitiatorName string `xml:"initiators>initiator-info>initiator-name,omitempty"`
 }
 
 // VServerIgroupsResponse creates correct response obj
@@ -60,7 +60,6 @@ func (v VServer) RemoveInitiator(vServerName string, iGroupName string, initiato
 	req.Params.XMLName = xml.Name{Local: "igroup-remove"}
 	req.Params.VServerIgroupInfo = VServerIgroupInfo{
 		InitiatorGroupName: iGroupName,
-		Initiators:         initiators,
 	}
 
 	r := &VServerIgroupsResponse{}

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -28,6 +28,7 @@ type VServerIgroupInfo struct {
 	InitiatorGroupUUID string `xml:"initiator-group-uuid,omitempty"`
 	//Initiators         *[]string `xml:"initiators>initiator-info,omitempty"`
 	InitiatorName string `xml:"initiator,omitempty"`
+	Force         bool   `xml:"force_remove,omitempty"`
 }
 
 // VServerIgroupsResponse creates correct response obj
@@ -54,13 +55,14 @@ func (v VServer) AddInitiator(vServerName string, iGroupName string, initiator s
 }
 
 // RemoveInitiator add an initiator to an igroup
-func (v VServer) RemoveInitiator(vServerName string, iGroupName string, initiator string) (*VServerIgroupsResponse, *http.Response, error) {
+func (v VServer) RemoveInitiator(vServerName string, iGroupName string, initiator string, force bool) (*VServerIgroupsResponse, *http.Response, error) {
 	req := v.newVServerIgroupsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "igroup-remove"}
 	req.Params.VServerIgroupInfo = VServerIgroupInfo{
 		InitiatorGroupName: iGroupName,
 		InitiatorName:      initiator,
+		Force: force
 	}
 
 	r := &VServerIgroupsResponse{}

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -62,7 +62,7 @@ func (v VServer) RemoveInitiator(vServerName string, iGroupName string, initiato
 	req.Params.VServerIgroupInfo = VServerIgroupInfo{
 		InitiatorGroupName: iGroupName,
 		InitiatorName:      initiator,
-		Force: force
+		Force:              force,
 	}
 
 	r := &VServerIgroupsResponse{}

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -26,7 +26,8 @@ type VServerIgroupInfo struct {
 	PortsetName        string    `xml:"initiator-group-portset-name,omitempty"`
 	InitiatorGroupName string    `xml:"initiator-group-name,omitempty"`
 	InitiatorGroupUUID string    `xml:"initiator-group-uuid,omitempty"`
-	Initiators         *[]string `xml:"initiators>initiator-name,omitempty"`
+	Initiators         *[]string `xml:"initiators>initiator-info,omitempty"`
+	InitiatorName      string    `xml:"initiators>initiator-info>initiator-name,omitempty"`
 }
 
 // VServerIgroupsResponse creates correct response obj
@@ -38,13 +39,13 @@ type VServerIgroupsResponse struct {
 }
 
 // AddInitiator add an initiator to an igroup
-func (v VServer) AddInitiator(vServerName string, iGroupName string, initiators *[]string) (*VServerIgroupsResponse, *http.Response, error) {
+func (v VServer) AddInitiator(vServerName string, iGroupName string, initiator string) (*VServerIgroupsResponse, *http.Response, error) {
 	req := v.newVServerIgroupsRequest()
 	req.Base.Name = vServerName
 	req.Params.XMLName = xml.Name{Local: "igroup-add"}
 	req.Params.VServerIgroupInfo = VServerIgroupInfo{
 		InitiatorGroupName: iGroupName,
-		Initiators:         initiators,
+		InitiatorName:      initiator,
 	}
 
 	r := &VServerIgroupsResponse{}

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -26,9 +26,8 @@ type VServerIgroupInfo struct {
 	PortsetName        string `xml:"initiator-group-portset-name,omitempty"`
 	InitiatorGroupName string `xml:"initiator-group-name,omitempty"`
 	InitiatorGroupUUID string `xml:"initiator-group-uuid,omitempty"`
-	//Initiators         *[]string `xml:"initiators>initiator-info,omitempty"`
-	InitiatorName string `xml:"initiator,omitempty"`
-	Force         bool   `xml:"force,omitempty"`
+	InitiatorName      string `xml:"initiator,omitempty"`
+	Force              bool   `xml:"force,omitempty"`
 }
 
 // VServerIgroupsResponse creates correct response obj

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -27,7 +27,7 @@ type VServerIgroupInfo struct {
 	InitiatorGroupName string `xml:"initiator-group-name,omitempty"`
 	InitiatorGroupUUID string `xml:"initiator-group-uuid,omitempty"`
 	//Initiators         *[]string `xml:"initiators>initiator-info,omitempty"`
-	InitiatorName string `xml:"initiator-name,omitempty"`
+	InitiatorName string `xml:"initiator,omitempty"`
 }
 
 // VServerIgroupsResponse creates correct response obj

--- a/netapp/vserver-igroups.go
+++ b/netapp/vserver-igroups.go
@@ -27,7 +27,7 @@ type VServerIgroupInfo struct {
 	InitiatorGroupName string `xml:"initiator-group-name,omitempty"`
 	InitiatorGroupUUID string `xml:"initiator-group-uuid,omitempty"`
 	//Initiators         *[]string `xml:"initiators>initiator-info,omitempty"`
-	InitiatorName string `xml:"initiators>initiator-info>initiator-name,omitempty"`
+	InitiatorName string `xml:"initiator-name,omitempty"`
 }
 
 // VServerIgroupsResponse creates correct response obj


### PR DESCRIPTION
Hi Kazuhiko

I had to to add the following for my ONTAP 9.5 use case:
- Add/Remove an initiator from an igroup
- List export rules by vserver

Tested against ONTAP 9.5 Simulator using https://github.com/AlpineCoder/go-netapp-test

Can you please review and merge if it is OK?

Best regards,
Roger