### PR TITLE
fix that SSLVerify option gives inverse configration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ go:
   - "1.11"
 
 go_import_path: github.com/pepabo/go-netapp
+env:
+  - GO111MODULE=auto
 
 # Only build pull requests, pushes to the master branch, and branches
 # starting with `test-`. This is a convenient way to push branches to

--- a/netapp/netapp.go
+++ b/netapp/netapp.go
@@ -327,7 +327,7 @@ func getClientCertificate(options *ClientOptions) (*tls.Certificate, error) {
 }
 
 func newTLSConfig(options *ClientOptions) (*tls.Config, error) {
-	tlsConfig := &tls.Config{InsecureSkipVerify: options.SSLVerify}
+	tlsConfig := &tls.Config{InsecureSkipVerify: !options.SSLVerify}
 
 	// If a CA cert is provided then let's read it in so we can validate the
 	// scrape target's certificate properly.


### PR DESCRIPTION
go-netapp seems to **skip** ssl verification when `SSLVerify` option is `true`.
I think that this is bug because, in older go-netapp version,  `SSLVerify=true` gives **doing** ssl verification.

I fixed `tls.Config.InsecureSkipVerify` setting.